### PR TITLE
PWB map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,7 @@ name = "alpha_g_detector"
 version = "0.1.0"
 dependencies = [
  "crc32c",
+ "lazy_static",
  "midasio",
  "thiserror",
 ]

--- a/detector/Cargo.toml
+++ b/detector/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "https://docs.rs/alpha_g_detector"
 
 [dependencies]
 crc32c = "0.6"
+lazy_static = "1.4"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/detector/src/padwing.rs
+++ b/detector/src/padwing.rs
@@ -1,6 +1,12 @@
 use std::fmt;
 use thiserror::Error;
 
+/// Pad and PWB map.
+///
+/// There are a total of 64 Padwing boards (8 columns and 8 rows). Each PWB
+/// has 4 columns and 72 rows of pads, for a total of 32 columns and 576 rows.
+pub mod map;
+
 /// Sampling rate (samples per second) of the channels that receive the radial
 /// Time Projection Chamber cathode pad signals.
 pub const PADWING_RATE: f64 = 62.5e6;
@@ -35,7 +41,7 @@ pub struct TryBoardIdFromUnsignedError {
 // Note: The device ID is just the first 4 bytes of the MAC address as
 // little endian u32. Maybe remove the last u32 in the future, and just get it
 // from the MAC address.
-const PADWINGBOARDS: [(&str, [u8; 6], u32); 64] = [
+const PADWING_BOARDS: [(&str, [u8; 6], u32); 64] = [
     ("00", [236, 40, 255, 135, 84, 2], 2281646316),
     ("01", [236, 40, 250, 162, 84, 2], 2734303468),
     ("02", [236, 40, 136, 108, 84, 2], 1820862700),
@@ -120,7 +126,7 @@ impl TryFrom<&str> for BoardId {
     type Error = ParseBoardIdError;
 
     fn try_from(name: &str) -> Result<Self, Self::Error> {
-        for triplet in PADWINGBOARDS {
+        for triplet in PADWING_BOARDS {
             if name == triplet.0 {
                 return Ok(BoardId {
                     name: triplet.0,
@@ -138,7 +144,7 @@ impl TryFrom<[u8; 6]> for BoardId {
     type Error = TryBoardIdFromMacAddressError;
 
     fn try_from(mac: [u8; 6]) -> Result<Self, Self::Error> {
-        for triplet in PADWINGBOARDS {
+        for triplet in PADWING_BOARDS {
             if mac == triplet.1 {
                 return Ok(BoardId {
                     name: triplet.0,
@@ -154,7 +160,7 @@ impl TryFrom<u32> for BoardId {
     type Error = TryBoardIdFromUnsignedError;
 
     fn try_from(device_id: u32) -> Result<Self, Self::Error> {
-        for triplet in PADWINGBOARDS {
+        for triplet in PADWING_BOARDS {
             if device_id == triplet.2 {
                 return Ok(BoardId {
                     name: triplet.0,

--- a/detector/src/padwing.rs
+++ b/detector/src/padwing.rs
@@ -773,7 +773,7 @@ impl TryFrom<u16> for FpnChannelId {
 /// Chamber.
 // The internal u16 does NOT correspond to the readout index.
 // It corresponds to the channel index 1, 2, 3, ..., 72.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct PadChannelId(u16);
 impl TryFrom<u16> for PadChannelId {
     type Error = TryChannelIdFromUnsignedError;

--- a/detector/src/padwing.rs
+++ b/detector/src/padwing.rs
@@ -1,6 +1,11 @@
 use std::fmt;
 use thiserror::Error;
 
+// Only imported for documentation. If you notice that this is no longer the
+// case, please open an issue/PR.
+#[allow(unused_imports)]
+use crate::padwing::map::TpcPwbPosition;
+
 /// Pad and PWB map.
 ///
 /// There are a total of 64 Padwing boards (8 columns and 8 rows). Each PWB
@@ -110,12 +115,11 @@ const PADWING_BOARDS: [(&str, [u8; 6], u32); 64] = [
 
 /// Identity of a physical PadWing board.
 ///
-/// It is important to notice that a [`BoardId`] is different to a [`ModuleId`].
-/// The former identifies a physical PadWing board, while the latter is a fixed
-/// ID that maps a module to cathode pads. The mapping between
-/// [`BoardId`] and [`ModuleId`] depends on the run number e.g. we switch an old
-/// board for a new board. You can see the [`ModuleId`] as the slot in which a
-/// board is plugged, which always maps to the same cathode pads.
+/// It is important to notice that a [`BoardId`] is different to a
+/// [`TpcPwbPosition`]. The former identifies a physical PadWing board, while
+/// the latter is a fixed position that maps a location in the rTPC. The mapping
+/// between [`BoardId`] and [`TpcPwbPosition`] depends on the run number e.g. we
+/// switch an old board for a new board.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct BoardId {
     name: &'static str,

--- a/detector/src/padwing/map.rs
+++ b/detector/src/padwing/map.rs
@@ -1,0 +1,196 @@
+use crate::padwing::BoardId;
+use lazy_static::lazy_static;
+use std::collections::HashMap;
+use thiserror::Error;
+
+/// The error type returned when conversion from [`usize`] to Row or Column
+/// fails.
+#[derive(Debug, Error)]
+#[error("unknown conversion from {input} to row or column")]
+pub struct TryPositionFromIndexError {
+    input: usize,
+}
+
+/// Column of a Padwing board in the rTPC.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TpcPwbColumn(usize);
+impl TryFrom<usize> for TpcPwbColumn {
+    type Error = TryPositionFromIndexError;
+
+    /// Convert from a `usize` (`0..=7`) to a [`TpcPwbColumn`].
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        if value < 8 {
+            Ok(Self(value))
+        } else {
+            Err(TryPositionFromIndexError { input: value })
+        }
+    }
+}
+
+/// Row of a Padwing board in the rTPC.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TpcPwbRow(usize);
+impl TryFrom<usize> for TpcPwbRow {
+    type Error = TryPositionFromIndexError;
+
+    /// Convert from a `usize` (`0..=7`) to a [`TpcPwbRow`].
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        if value < 8 {
+            Ok(Self(value))
+        } else {
+            Err(TryPositionFromIndexError { input: value })
+        }
+    }
+}
+
+/// Position of a Padwing board in the rTPC.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct TpcPwbPosition {
+    column: TpcPwbColumn,
+    row: TpcPwbRow,
+}
+impl TpcPwbPosition {
+    /// Return the column of the Padwing board within the rTPC.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use alpha_g_detector::padwing::ParseBoardIdError;
+    /// # use alpha_g_detector::padwing::map::MapTpcPwbPositionError;
+    /// # use alpha_g_detector::padwing::map::TryPositionFromIndexError;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use alpha_g_detector::padwing::map::{tpc_pwb_position, TpcPwbColumn};
+    /// use alpha_g_detector::padwing::BoardId;
+    ///
+    /// let run_number = 5000;
+    /// let board_id = BoardId::try_from("26")?;
+    /// let position = tpc_pwb_position(run_number, board_id)?;
+    ///
+    /// assert_eq!(position.column(), TpcPwbColumn::try_from(1)?);
+    /// # Ok(())
+    /// # }
+    pub fn column(&self) -> TpcPwbColumn {
+        self.column
+    }
+    /// Return the row of the Padwing board within the rTPC.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use alpha_g_detector::padwing::ParseBoardIdError;
+    /// # use alpha_g_detector::padwing::map::MapTpcPwbPositionError;
+    /// # use alpha_g_detector::padwing::map::TryPositionFromIndexError;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use alpha_g_detector::padwing::map::{tpc_pwb_position, TpcPwbRow};
+    /// use alpha_g_detector::padwing::BoardId;
+    ///
+    /// let run_number = 5000;
+    /// let board_id = BoardId::try_from("26")?;
+    /// let position = tpc_pwb_position(run_number, board_id)?;
+    ///
+    /// assert_eq!(position.row(), TpcPwbRow::try_from(6)?);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn row(&self) -> TpcPwbRow {
+        self.row
+    }
+}
+
+// Map of all PWB boards as installed on the rTPC in run number 4418 (included).
+// First index is column, second index is row.
+// The value is the board name.
+//
+// When you add a new map, remember to add the unit tests for it:
+//     - Uniqueness of all &str.
+//     - Validity of all &str.
+//     - Test inverse map.
+const PADWING_BOARDS_4418: [[&str; 8]; 8] = [
+    ["12", "13", "14", "02", "11", "17", "18", "19"],
+    ["20", "21", "22", "23", "24", "25", "26", "27"],
+    ["46", "29", "08", "77", "10", "33", "34", "35"],
+    ["36", "37", "01", "39", "76", "41", "42", "40"],
+    ["44", "49", "07", "78", "03", "04", "45", "15"],
+    ["52", "53", "54", "55", "56", "57", "58", "05"],
+    ["60", "00", "06", "63", "64", "65", "66", "67"],
+    ["68", "69", "70", "71", "72", "73", "74", "75"],
+];
+
+fn inverse_pwb_map(map: [[&str; 8]; 8]) -> HashMap<BoardId, TpcPwbPosition> {
+    let mut inverse = HashMap::new();
+    for (column, row) in map.iter().enumerate() {
+        for (row, name) in row.iter().enumerate() {
+            inverse.insert(
+                // Safe to unwrap. Unit tests should validate that this cant fail.
+                BoardId::try_from(*name).unwrap(),
+                TpcPwbPosition {
+                    column: TpcPwbColumn::try_from(column).unwrap(),
+                    row: TpcPwbRow::try_from(row).unwrap(),
+                },
+            );
+        }
+    }
+    inverse
+}
+
+lazy_static! {
+    static ref INV_PADWING_BOARDS_4418: HashMap<BoardId, TpcPwbPosition> =
+        inverse_pwb_map(PADWING_BOARDS_4418);
+}
+
+/// The error type returned when mapping a [`BoardId`] to a [`TpcPwbPosition`]
+/// fails.
+#[derive(Debug, Error)]
+pub enum MapTpcPwbPositionError {
+    /// There is no mapping available for the given `run_number`.
+    #[error("no mapping available for run number {run_number}")]
+    MissingMap { run_number: u32 },
+    /// The given [`BoardId`] is not in the map for the given `run_number`.
+    #[error("pwb `{}` not found in map for run number {run_number}", board_id.name())]
+    BoardIdNotFound { run_number: u32, board_id: BoardId },
+}
+
+/// Map a [`BoardId`] to a [`TpcPwbPosition`] for a given `run_number`.
+/// Returns an error if there is no map available for the given `run_number` or
+/// if the given [`BoardId`] is not in installed in the rTPC for the given
+/// `run_number`.
+///
+/// # Examples
+///
+/// ```
+/// # use alpha_g_detector::padwing::ParseBoardIdError;
+/// # use alpha_g_detector::padwing::map::MapTpcPwbPositionError;
+/// # use alpha_g_detector::padwing::map::TryPositionFromIndexError;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use alpha_g_detector::padwing::map::{tpc_pwb_position, TpcPwbColumn, TpcPwbRow};
+/// use alpha_g_detector::padwing::BoardId;
+///
+/// let run_number = 5000;
+/// let board_id = BoardId::try_from("26")?;
+///
+/// let position = tpc_pwb_position(run_number, board_id)?;
+///
+/// assert_eq!(position.column(), TpcPwbColumn::try_from(1)?);
+/// assert_eq!(position.row(), TpcPwbRow::try_from(6)?);
+/// # Ok(())
+/// # }
+pub fn tpc_pwb_position(
+    run_number: u32,
+    board_id: BoardId,
+) -> Result<TpcPwbPosition, MapTpcPwbPositionError> {
+    let position_map = match run_number {
+        4418.. => &INV_PADWING_BOARDS_4418,
+        _ => return Err(MapTpcPwbPositionError::MissingMap { run_number }),
+    };
+
+    position_map
+        .get(&board_id)
+        .copied()
+        .ok_or(MapTpcPwbPositionError::BoardIdNotFound {
+            run_number,
+            board_id,
+        })
+}
+
+#[cfg(test)]
+mod tests;

--- a/detector/src/padwing/map.rs
+++ b/detector/src/padwing/map.rs
@@ -43,54 +43,6 @@ impl TryFrom<usize> for TpcPwbRow {
     }
 }
 
-/// Position of a Padwing board in the rTPC.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct TpcPwbPosition {
-    column: TpcPwbColumn,
-    row: TpcPwbRow,
-}
-impl TpcPwbPosition {
-    /// Return the column of the Padwing board within the rTPC.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use alpha_g_detector::padwing::map::{tpc_pwb_position, TpcPwbColumn};
-    /// use alpha_g_detector::padwing::BoardId;
-    ///
-    /// let run_number = 5000;
-    /// let board_id = BoardId::try_from("26")?;
-    /// let position = tpc_pwb_position(run_number, board_id)?;
-    ///
-    /// assert_eq!(position.column(), TpcPwbColumn::try_from(1)?);
-    /// # Ok(())
-    /// # }
-    pub fn column(&self) -> TpcPwbColumn {
-        self.column
-    }
-    /// Return the row of the Padwing board within the rTPC.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use alpha_g_detector::padwing::map::{tpc_pwb_position, TpcPwbRow};
-    /// use alpha_g_detector::padwing::BoardId;
-    ///
-    /// let run_number = 5000;
-    /// let board_id = BoardId::try_from("26")?;
-    /// let position = tpc_pwb_position(run_number, board_id)?;
-    ///
-    /// assert_eq!(position.row(), TpcPwbRow::try_from(6)?);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn row(&self) -> TpcPwbRow {
-        self.row
-    }
-}
-
 // Map of all PWB boards as installed on the rTPC in run number 4418 (included).
 // First index is column, second index is row.
 // The value is the board name.
@@ -101,7 +53,7 @@ impl TpcPwbPosition {
 //     - Test inverse map.
 //
 // Also remember to add the inverse (actually needed) map to the lazy_static
-// below.
+// below and update TpcPwbPosition::try_new.
 const PADWING_BOARDS_4418: [[&str; 8]; 8] = [
     ["12", "13", "14", "02", "11", "17", "18", "19"],
     ["20", "21", "22", "23", "24", "25", "26", "27"],
@@ -148,43 +100,84 @@ pub enum MapTpcPwbPositionError {
     BoardIdNotFound { run_number: u32, board_id: BoardId },
 }
 
-/// Map a [`BoardId`] to a [`TpcPwbPosition`] for a given `run_number`.
-/// Returns an error if there is no map available for the given `run_number` or
-/// if the given [`BoardId`] is not in installed in the rTPC for that
-/// `run_number`.
-///
-/// # Examples
-///
-/// ```
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// use alpha_g_detector::padwing::map::{tpc_pwb_position, TpcPwbColumn, TpcPwbRow};
-/// use alpha_g_detector::padwing::BoardId;
-///
-/// let run_number = 5000;
-/// let board_id = BoardId::try_from("26")?;
-///
-/// let position = tpc_pwb_position(run_number, board_id)?;
-///
-/// assert_eq!(position.column(), TpcPwbColumn::try_from(1)?);
-/// assert_eq!(position.row(), TpcPwbRow::try_from(6)?);
-/// # Ok(())
-/// # }
-pub fn tpc_pwb_position(
-    run_number: u32,
-    board_id: BoardId,
-) -> Result<TpcPwbPosition, MapTpcPwbPositionError> {
-    let position_map = match run_number {
-        4418.. => &INV_PADWING_BOARDS_4418,
-        _ => return Err(MapTpcPwbPositionError::MissingMap { run_number }),
-    };
+/// Position of a Padwing board in the rTPC.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct TpcPwbPosition {
+    column: TpcPwbColumn,
+    row: TpcPwbRow,
+}
+impl TpcPwbPosition {
+    /// Map a [`BoardId`] to a [`TpcPwbPosition`] for a given `run_number`.
+    /// Returns an error if there is no map available for the given `run_number`
+    /// or if the given [`BoardId`] is not installed in the rTPC for that
+    /// `run_number`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use alpha_g_detector::padwing::map::TpcPwbPosition;
+    /// use alpha_g_detector::padwing::BoardId;
+    ///
+    /// let run_number = 5000;
+    /// let board_id = BoardId::try_from("26")?;
+    ///
+    /// let position = TpcPwbPosition::try_new(run_number, board_id)?;
+    /// # Ok(())
+    /// # }
+    pub fn try_new(run_number: u32, board_id: BoardId) -> Result<Self, MapTpcPwbPositionError> {
+        let position_map = match run_number {
+            4418.. => &INV_PADWING_BOARDS_4418,
+            _ => return Err(MapTpcPwbPositionError::MissingMap { run_number }),
+        };
 
-    position_map
-        .get(&board_id)
-        .copied()
-        .ok_or(MapTpcPwbPositionError::BoardIdNotFound {
-            run_number,
-            board_id,
-        })
+        position_map
+            .get(&board_id)
+            .copied()
+            .ok_or(MapTpcPwbPositionError::BoardIdNotFound {
+                run_number,
+                board_id,
+            })
+    }
+    /// Return the column of the Padwing board within the rTPC.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use alpha_g_detector::padwing::map::{TpcPwbPosition, TpcPwbColumn};
+    /// use alpha_g_detector::padwing::BoardId;
+    ///
+    /// let run_number = 5000;
+    /// let board_id = BoardId::try_from("26")?;
+    /// let position = TpcPwbPosition::try_new(run_number, board_id)?;
+    ///
+    /// assert_eq!(position.column(), TpcPwbColumn::try_from(1)?);
+    /// # Ok(())
+    /// # }
+    pub fn column(&self) -> TpcPwbColumn {
+        self.column
+    }
+    /// Return the row of the Padwing board within the rTPC.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use alpha_g_detector::padwing::map::{TpcPwbPosition, TpcPwbRow};
+    /// use alpha_g_detector::padwing::BoardId;
+    ///
+    /// let run_number = 5000;
+    /// let board_id = BoardId::try_from("26")?;
+    /// let position = TpcPwbPosition::try_new(run_number, board_id)?;
+    ///
+    /// assert_eq!(position.row(), TpcPwbRow::try_from(6)?);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn row(&self) -> TpcPwbRow {
+        self.row
+    }
 }
 
 /// Column of a pad in a Padwing Board.
@@ -219,59 +212,12 @@ impl TryFrom<usize> for PwbPadRow {
     }
 }
 
-/// Position of a pad in a Padwing Board.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct PwbPadPosition {
-    column: PwbPadColumn,
-    row: PwbPadRow,
-}
-impl PwbPadPosition {
-    /// Return the column of the pad within the Padwing Board.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use alpha_g_detector::padwing::map::{pwb_pad_position, PwbPadColumn};
-    /// use alpha_g_detector::padwing::{AfterId, PadChannelId};
-    ///
-    /// let run_number = 5000;
-    /// let after_id = AfterId::try_from('A')?;
-    /// let pad_channel_id = PadChannelId::try_from(1)?;
-    ///
-    /// let position = pwb_pad_position(run_number, after_id, pad_channel_id)?;
-    ///
-    /// assert_eq!(position.column(), PwbPadColumn::try_from(1)?);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn column(&self) -> PwbPadColumn {
-        self.column
-    }
-    /// Return the row of the pad within the Padwing Board.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use alpha_g_detector::padwing::map::{pwb_pad_position, PwbPadRow};
-    /// use alpha_g_detector::padwing::{AfterId, PadChannelId};
-    ///
-    /// let run_number = 5000;
-    /// let after_id = AfterId::try_from('A')?;
-    /// let pad_channel_id = PadChannelId::try_from(1)?;
-    ///
-    /// let position = pwb_pad_position(run_number, after_id, pad_channel_id)?;
-    ///
-    /// assert_eq!(position.row(), PwbPadRow::try_from(0)?);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn row(&self) -> PwbPadRow {
-        self.row
-    }
-}
-
+// I don't see the following mapping between (AFTER, channel) -> Position
+// changing or being updated any time soon. It would imply an excessive amount
+// of hardware work. Nonetheless, I am leaving this mapping as a function of
+// `run_number` to be consistent with the anode wire mapping. If it changes at
+// some point, just do the same as the above PWB mapping or the anode wire
+// mapping.
 lazy_static! {
     // Map copied directly from agana/Feam.hh written by K.O.
     static ref INV_PADS_0: HashMap<(AfterId, PadChannelId), PwbPadPosition> = {
@@ -320,13 +266,6 @@ lazy_static! {
     };
 }
 
-// I don't see the above mapping between (AFTER, channel) -> Position
-// changing or being updated any time soon. It would imply an excessive amount
-// of hardware work. Nonetheless, I am leaving this mapping as a function of
-// `run_number` to be consistent with the anode wire mapping. If it changes at
-// some point, just do the same as the above PWB mapping or the anode wire
-// mapping.
-
 /// The error type returned when mapping an [`AfterId`] and [`PadChannelId`] to a
 /// [`PwbPadPosition`] fails.
 #[derive(Debug, Error)]
@@ -335,35 +274,208 @@ pub struct MapPwbPadPositionError {
     run_number: u32,
 }
 
-/// Map an [`AfterId`] and [`PadChannelId`] to a [`PwbPadPosition`] for a given
-/// `run_number`. Returns an error if there is no map available for that
-/// `run_number`.
-///
-/// # Examples
-///
-/// ```
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// use alpha_g_detector::padwing::map::{pwb_pad_position, PwbPadColumn, PwbPadRow};
-/// use alpha_g_detector::padwing::{AfterId, PadChannelId};
-///
-/// let run_number = 5000;
-/// let after_id = AfterId::try_from('A')?;
-/// let pad_channel_id = PadChannelId::try_from(1)?;
-///
-/// let position = pwb_pad_position(run_number, after_id, pad_channel_id)?;
-///
-/// assert_eq!(position.column(), PwbPadColumn::try_from(1)?);
-/// assert_eq!(position.row(), PwbPadRow::try_from(0)?);
-/// # Ok(())
-/// # }
-/// ```
-pub fn pwb_pad_position(
-    _run_number: u32,
-    after_id: AfterId,
-    pad_channel_id: PadChannelId,
-) -> Result<PwbPadPosition, MapPwbPadPositionError> {
-    let position_map = &INV_PADS_0;
-    Ok(*position_map.get(&(after_id, pad_channel_id)).unwrap())
+/// Position of a pad in a Padwing Board.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct PwbPadPosition {
+    column: PwbPadColumn,
+    row: PwbPadRow,
+}
+impl PwbPadPosition {
+    /// Map an [`AfterId`] and [`PadChannelId`] to a [`PwbPadPosition`] for a
+    /// given `run_number`. Returns an error if there is no map available for
+    /// that `run_number`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use alpha_g_detector::padwing::map::PwbPadPosition;
+    /// use alpha_g_detector::padwing::{AfterId, PadChannelId};
+    ///
+    /// let run_number = 5000;
+    /// let after_id = AfterId::try_from('A')?;
+    /// let pad_channel_id = PadChannelId::try_from(1)?;
+    ///
+    /// let position = PwbPadPosition::try_new(run_number, after_id, pad_channel_id)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn try_new(
+        _run_number: u32,
+        after_id: AfterId,
+        pad_channel_id: PadChannelId,
+    ) -> Result<PwbPadPosition, MapPwbPadPositionError> {
+        let position_map = &INV_PADS_0;
+        Ok(*position_map.get(&(after_id, pad_channel_id)).unwrap())
+    }
+    /// Return the column of the pad within the Padwing Board.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use alpha_g_detector::padwing::map::{PwbPadPosition, PwbPadColumn};
+    /// use alpha_g_detector::padwing::{AfterId, PadChannelId};
+    ///
+    /// let run_number = 5000;
+    /// let after_id = AfterId::try_from('A')?;
+    /// let pad_channel_id = PadChannelId::try_from(1)?;
+    ///
+    /// let position = PwbPadPosition::try_new(run_number, after_id, pad_channel_id)?;
+    ///
+    /// assert_eq!(position.column(), PwbPadColumn::try_from(1)?);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn column(&self) -> PwbPadColumn {
+        self.column
+    }
+    /// Return the row of the pad within the Padwing Board.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use alpha_g_detector::padwing::map::{PwbPadPosition, PwbPadRow};
+    /// use alpha_g_detector::padwing::{AfterId, PadChannelId};
+    ///
+    /// let run_number = 5000;
+    /// let after_id = AfterId::try_from('A')?;
+    /// let pad_channel_id = PadChannelId::try_from(1)?;
+    ///
+    /// let position = PwbPadPosition::try_new(run_number, after_id, pad_channel_id)?;
+    ///
+    /// assert_eq!(position.row(), PwbPadRow::try_from(0)?);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn row(&self) -> PwbPadRow {
+        self.row
+    }
+}
+
+/// Column of a pad in the rTPC.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TpcPadColumn(usize);
+impl TryFrom<usize> for TpcPadColumn {
+    type Error = TryPositionFromIndexError;
+
+    /// Convert from a `usize` (`0..=31`) to a [`TpcPadColumn`].
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        if value < 32 {
+            Ok(TpcPadColumn(value))
+        } else {
+            Err(TryPositionFromIndexError { input: value })
+        }
+    }
+}
+
+/// Row of a pad in the rTPC.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TpcPadRow(usize);
+impl TryFrom<usize> for TpcPadRow {
+    type Error = TryPositionFromIndexError;
+
+    /// Convert from a `usize` (`0..=575`) to a [`TpcPadRow`].
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        if value < 576 {
+            Ok(TpcPadRow(value))
+        } else {
+            Err(TryPositionFromIndexError { input: value })
+        }
+    }
+}
+
+/// Position of a pad in the rTPC.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct TpcPadPosition {
+    column: TpcPadColumn,
+    row: TpcPadRow,
+}
+impl TpcPadPosition {
+    /// Map a [`TpcPwbPosition`] and [`PwbPadPosition`] to a [`TpcPadPosition`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use alpha_g_detector::padwing::map::{TpcPadPosition, TpcPwbPosition, PwbPadPosition};
+    /// use alpha_g_detector::padwing::{AfterId, PadChannelId, BoardId};
+    ///
+    /// let run_number = 5000;
+    /// let board = BoardId::try_from("26")?;
+    /// let board_pos = TpcPwbPosition::try_new(run_number, board)?;
+    ///
+    /// let after = AfterId::try_from('A')?;
+    /// let pad_channel = PadChannelId::try_from(1)?;
+    /// let pad_pos = PwbPadPosition::try_new(run_number, after, pad_channel)?;
+    ///
+    /// let tpc_pad_position = TpcPadPosition::new(board_pos, pad_pos);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new(board_position: TpcPwbPosition, pad_position: PwbPadPosition) -> Self {
+        let TpcPwbPosition { column, row } = board_position;
+        let PwbPadPosition {
+            column: pad_column,
+            row: pad_row,
+        } = pad_position;
+        let column = TpcPadColumn::try_from(column.0 * 4 + pad_column.0).unwrap();
+        let row = TpcPadRow::try_from(row.0 * 72 + pad_row.0).unwrap();
+        TpcPadPosition { column, row }
+    }
+    /// Return the column of the pad within the rTPC.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use alpha_g_detector::padwing::map::{TpcPadPosition, TpcPadColumn, TpcPwbPosition, PwbPadPosition};
+    /// use alpha_g_detector::padwing::{AfterId, PadChannelId, BoardId};
+    ///
+    /// let run_number = 5000;
+    /// let board = BoardId::try_from("26")?;
+    /// let board_pos = TpcPwbPosition::try_new(run_number, board)?;
+    ///
+    /// let after = AfterId::try_from('A')?;
+    /// let pad_channel = PadChannelId::try_from(1)?;
+    /// let pad_pos = PwbPadPosition::try_new(run_number, after, pad_channel)?;
+    ///
+    /// let tpc_pad_position = TpcPadPosition::new(board_pos, pad_pos);
+    ///
+    /// assert_eq!(tpc_pad_position.column(), TpcPadColumn::try_from(5)?);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn column(&self) -> TpcPadColumn {
+        self.column
+    }
+    /// Return the row of the pad within the rTPC.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use alpha_g_detector::padwing::map::{TpcPadPosition, TpcPadRow, TpcPwbPosition, PwbPadPosition};
+    /// use alpha_g_detector::padwing::{AfterId, PadChannelId, BoardId};
+    ///
+    /// let run_number = 5000;
+    /// let board = BoardId::try_from("26")?;
+    /// let board_pos = TpcPwbPosition::try_new(run_number, board)?;
+    ///
+    /// let after = AfterId::try_from('A')?;
+    /// let pad_channel = PadChannelId::try_from(1)?;
+    /// let pad_pos = PwbPadPosition::try_new(run_number, after, pad_channel)?;
+    ///
+    /// let tpc_pad_position = TpcPadPosition::new(board_pos, pad_pos);
+    ///
+    /// assert_eq!(tpc_pad_position.row(), TpcPadRow::try_from(432)?);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn row(&self) -> TpcPadRow {
+        self.row
+    }
 }
 
 #[cfg(test)]

--- a/detector/src/padwing/map/tests.rs
+++ b/detector/src/padwing/map/tests.rs
@@ -101,7 +101,7 @@ fn tpc_pwb_position_missing_map() {
     for i in 0..4418 {
         for (name, _mac, _id) in PADWING_BOARDS {
             let board_id = BoardId::try_from(name).unwrap();
-            match tpc_pwb_position(i, board_id) {
+            match TpcPwbPosition::try_new(i, board_id) {
                 Err(MapTpcPwbPositionError::MissingMap { run_number }) => assert_eq!(run_number, i),
                 _ => unreachable!(),
             }
@@ -119,7 +119,8 @@ fn inverse_map_tpc_pwb_position_4418() {
                     row: TpcPwbRow(j),
                 };
                 assert_eq!(
-                    tpc_pwb_position(run_number, BoardId::try_from(*board).unwrap()).unwrap(),
+                    TpcPwbPosition::try_new(run_number, BoardId::try_from(*board).unwrap())
+                        .unwrap(),
                     position
                 );
             }
@@ -173,7 +174,7 @@ fn pwb_pad_position_row() {
 fn pwb_pad_position_all_exist() {
     for after in 'A'..='D' {
         for channel in 1..=72 {
-            assert!(pwb_pad_position(
+            assert!(PwbPadPosition::try_new(
                 0,
                 AfterId::try_from(after).unwrap(),
                 PadChannelId::try_from(channel).unwrap()
@@ -187,7 +188,7 @@ fn pwb_pad_position_all_exist() {
 fn pwb_pad_position_correctness() {
     for (row, channel) in (19..=36).rev().enumerate() {
         assert_eq!(
-            pwb_pad_position(
+            PwbPadPosition::try_new(
                 0,
                 AfterId::try_from('A').unwrap(),
                 PadChannelId::try_from(channel).unwrap()
@@ -201,7 +202,7 @@ fn pwb_pad_position_correctness() {
     }
     for (row, channel) in (37..=54).rev().enumerate() {
         assert_eq!(
-            pwb_pad_position(
+            PwbPadPosition::try_new(
                 0,
                 AfterId::try_from('A').unwrap(),
                 PadChannelId::try_from(channel).unwrap()
@@ -215,7 +216,7 @@ fn pwb_pad_position_correctness() {
     }
     for (row, channel) in (19..=36).rev().enumerate() {
         assert_eq!(
-            pwb_pad_position(
+            PwbPadPosition::try_new(
                 0,
                 AfterId::try_from('B').unwrap(),
                 PadChannelId::try_from(channel).unwrap()
@@ -229,7 +230,7 @@ fn pwb_pad_position_correctness() {
     }
     for (row, channel) in (37..=54).rev().enumerate() {
         assert_eq!(
-            pwb_pad_position(
+            PwbPadPosition::try_new(
                 0,
                 AfterId::try_from('B').unwrap(),
                 PadChannelId::try_from(channel).unwrap()
@@ -243,7 +244,7 @@ fn pwb_pad_position_correctness() {
     }
     for (row, channel) in (1..=18).enumerate() {
         assert_eq!(
-            pwb_pad_position(
+            PwbPadPosition::try_new(
                 0,
                 AfterId::try_from('A').unwrap(),
                 PadChannelId::try_from(channel).unwrap()
@@ -257,7 +258,7 @@ fn pwb_pad_position_correctness() {
     }
     for (row, channel) in (55..=72).enumerate() {
         assert_eq!(
-            pwb_pad_position(
+            PwbPadPosition::try_new(
                 0,
                 AfterId::try_from('A').unwrap(),
                 PadChannelId::try_from(channel).unwrap()
@@ -271,7 +272,7 @@ fn pwb_pad_position_correctness() {
     }
     for (row, channel) in (1..=18).enumerate() {
         assert_eq!(
-            pwb_pad_position(
+            PwbPadPosition::try_new(
                 0,
                 AfterId::try_from('B').unwrap(),
                 PadChannelId::try_from(channel).unwrap()
@@ -285,7 +286,7 @@ fn pwb_pad_position_correctness() {
     }
     for (row, channel) in (55..=72).enumerate() {
         assert_eq!(
-            pwb_pad_position(
+            PwbPadPosition::try_new(
                 0,
                 AfterId::try_from('B').unwrap(),
                 PadChannelId::try_from(channel).unwrap()
@@ -299,7 +300,7 @@ fn pwb_pad_position_correctness() {
     }
     for (row, channel) in (55..=72).rev().enumerate() {
         assert_eq!(
-            pwb_pad_position(
+            PwbPadPosition::try_new(
                 0,
                 AfterId::try_from('D').unwrap(),
                 PadChannelId::try_from(channel).unwrap()
@@ -313,7 +314,7 @@ fn pwb_pad_position_correctness() {
     }
     for (row, channel) in (1..=18).rev().enumerate() {
         assert_eq!(
-            pwb_pad_position(
+            PwbPadPosition::try_new(
                 0,
                 AfterId::try_from('D').unwrap(),
                 PadChannelId::try_from(channel).unwrap()
@@ -327,7 +328,7 @@ fn pwb_pad_position_correctness() {
     }
     for (row, channel) in (55..=72).rev().enumerate() {
         assert_eq!(
-            pwb_pad_position(
+            PwbPadPosition::try_new(
                 0,
                 AfterId::try_from('C').unwrap(),
                 PadChannelId::try_from(channel).unwrap()
@@ -341,7 +342,7 @@ fn pwb_pad_position_correctness() {
     }
     for (row, channel) in (1..=18).rev().enumerate() {
         assert_eq!(
-            pwb_pad_position(
+            PwbPadPosition::try_new(
                 0,
                 AfterId::try_from('C').unwrap(),
                 PadChannelId::try_from(channel).unwrap()
@@ -355,7 +356,7 @@ fn pwb_pad_position_correctness() {
     }
     for (row, channel) in (37..=54).enumerate() {
         assert_eq!(
-            pwb_pad_position(
+            PwbPadPosition::try_new(
                 0,
                 AfterId::try_from('D').unwrap(),
                 PadChannelId::try_from(channel).unwrap()
@@ -369,7 +370,7 @@ fn pwb_pad_position_correctness() {
     }
     for (row, channel) in (19..=36).enumerate() {
         assert_eq!(
-            pwb_pad_position(
+            PwbPadPosition::try_new(
                 0,
                 AfterId::try_from('D').unwrap(),
                 PadChannelId::try_from(channel).unwrap()
@@ -383,7 +384,7 @@ fn pwb_pad_position_correctness() {
     }
     for (row, channel) in (37..=54).enumerate() {
         assert_eq!(
-            pwb_pad_position(
+            PwbPadPosition::try_new(
                 0,
                 AfterId::try_from('C').unwrap(),
                 PadChannelId::try_from(channel).unwrap()
@@ -397,7 +398,7 @@ fn pwb_pad_position_correctness() {
     }
     for (row, channel) in (19..=36).enumerate() {
         assert_eq!(
-            pwb_pad_position(
+            PwbPadPosition::try_new(
                 0,
                 AfterId::try_from('C').unwrap(),
                 PadChannelId::try_from(channel).unwrap()
@@ -408,5 +409,76 @@ fn pwb_pad_position_correctness() {
                 row: PwbPadRow(row + 54),
             }
         );
+    }
+}
+
+#[test]
+fn try_from_index_tpc_pad_column() {
+    for i in 0..=31 {
+        assert_eq!(TpcPadColumn::try_from(i).unwrap(), TpcPadColumn(i));
+    }
+    for i in 32..=19000 {
+        assert!(TpcPadColumn::try_from(i).is_err());
+    }
+}
+
+#[test]
+fn try_from_index_tpc_pad_row() {
+    for i in 0..=575 {
+        assert_eq!(TpcPadRow::try_from(i).unwrap(), TpcPadRow(i));
+    }
+    for i in 576..=19000 {
+        assert!(TpcPadRow::try_from(i).is_err());
+    }
+}
+
+#[test]
+fn tpc_pad_position_new() {
+    for column in 0..=31 {
+        let board_column = TpcPwbColumn::try_from(column / 4).unwrap();
+        let pad_column = PwbPadColumn::try_from(column % 4).unwrap();
+        for row in 0..=575 {
+            let board_row = TpcPwbRow::try_from(row / 72).unwrap();
+            let pad_row = PwbPadRow::try_from(row % 72).unwrap();
+
+            let board = TpcPwbPosition {
+                column: board_column,
+                row: board_row,
+            };
+            let pad = PwbPadPosition {
+                column: pad_column,
+                row: pad_row,
+            };
+
+            assert_eq!(
+                TpcPadPosition::new(board, pad),
+                TpcPadPosition {
+                    column: TpcPadColumn(column),
+                    row: TpcPadRow(row),
+                }
+            );
+        }
+    }
+}
+
+#[test]
+fn tpc_pad_position_column() {
+    for i in 0..=31 {
+        let position = TpcPadPosition {
+            column: TpcPadColumn(i),
+            row: TpcPadRow(0),
+        };
+        assert_eq!(position.column(), TpcPadColumn(i));
+    }
+}
+
+#[test]
+fn tpc_pad_position_row() {
+    for i in 0..=575 {
+        let position = TpcPadPosition {
+            column: TpcPadColumn(0),
+            row: TpcPadRow(i),
+        };
+        assert_eq!(position.row(), TpcPadRow(i));
     }
 }

--- a/detector/src/padwing/map/tests.rs
+++ b/detector/src/padwing/map/tests.rs
@@ -482,3 +482,71 @@ fn tpc_pad_position_row() {
         assert_eq!(position.row(), TpcPadRow(i));
     }
 }
+
+#[test]
+fn tpc_pad_position_bad_tpc_pwb_position() {
+    for run_number in 0..=4417 {
+        let board_id = BoardId::try_from("26").unwrap();
+        let after_id = AfterId::try_from('A').unwrap();
+        let channel_id = PadChannelId::try_from(1).unwrap();
+
+        assert!(matches!(
+            TpcPadPosition::try_new(run_number, board_id, after_id, channel_id),
+            Err(MapTpcPadPositionError::BadTpcPwbPosition(_))
+        ));
+    }
+}
+
+#[test]
+fn tpc_pad_position_try_new() {
+    let run_number = 4418;
+    for (column, row) in REGRESSION_GATE_KEEPER_4418.into_iter().enumerate() {
+        for (row, name) in row.into_iter().enumerate() {
+            let board_id = BoardId::try_from(name).unwrap();
+
+            let bottom_left_pad_position = TpcPadPosition {
+                column: TpcPadColumn(column * 4),
+                row: TpcPadRow(row * 72),
+            };
+            let after_a = AfterId::try_from('A').unwrap();
+            let channel_36 = PadChannelId::try_from(36).unwrap();
+            assert_eq!(
+                TpcPadPosition::try_new(run_number, board_id, after_a, channel_36).unwrap(),
+                bottom_left_pad_position
+            );
+
+            let top_left_pad_position = TpcPadPosition {
+                column: TpcPadColumn(column * 4),
+                row: TpcPadRow(row * 72 + 71),
+            };
+            let after_b = AfterId::try_from('B').unwrap();
+            let channel_37 = PadChannelId::try_from(37).unwrap();
+            assert_eq!(
+                TpcPadPosition::try_new(run_number, board_id, after_b, channel_37).unwrap(),
+                top_left_pad_position
+            );
+
+            let bottom_right_pad_position = TpcPadPosition {
+                column: TpcPadColumn(column * 4 + 3),
+                row: TpcPadRow(row * 72),
+            };
+            let after_d = AfterId::try_from('D').unwrap();
+            let channel_37 = PadChannelId::try_from(37).unwrap();
+            assert_eq!(
+                TpcPadPosition::try_new(run_number, board_id, after_d, channel_37).unwrap(),
+                bottom_right_pad_position
+            );
+
+            let top_right_pad_position = TpcPadPosition {
+                column: TpcPadColumn(column * 4 + 3),
+                row: TpcPadRow(row * 72 + 71),
+            };
+            let after_c = AfterId::try_from('C').unwrap();
+            let channel_36 = PadChannelId::try_from(36).unwrap();
+            assert_eq!(
+                TpcPadPosition::try_new(run_number, board_id, after_c, channel_36).unwrap(),
+                top_right_pad_position
+            );
+        }
+    }
+}

--- a/detector/src/padwing/map/tests.rs
+++ b/detector/src/padwing/map/tests.rs
@@ -126,3 +126,287 @@ fn inverse_map_tpc_pwb_position_4418() {
         }
     }
 }
+
+#[test]
+fn try_from_index_pwb_pad_column() {
+    for i in 0..=3 {
+        assert_eq!(PwbPadColumn::try_from(i).unwrap(), PwbPadColumn(i));
+    }
+    for i in 4..=19000 {
+        assert!(PwbPadColumn::try_from(i).is_err());
+    }
+}
+
+#[test]
+fn try_from_index_pwb_pad_row() {
+    for i in 0..=71 {
+        assert_eq!(PwbPadRow::try_from(i).unwrap(), PwbPadRow(i));
+    }
+    for i in 72..=19000 {
+        assert!(PwbPadRow::try_from(i).is_err());
+    }
+}
+
+#[test]
+fn pwb_pad_position_column() {
+    for i in 0..=3 {
+        let position = PwbPadPosition {
+            column: PwbPadColumn(i),
+            row: PwbPadRow(0),
+        };
+        assert_eq!(position.column(), PwbPadColumn(i));
+    }
+}
+
+#[test]
+fn pwb_pad_position_row() {
+    for i in 0..=71 {
+        let position = PwbPadPosition {
+            column: PwbPadColumn(0),
+            row: PwbPadRow(i),
+        };
+        assert_eq!(position.row(), PwbPadRow(i));
+    }
+}
+
+#[test]
+fn pwb_pad_position_all_exist() {
+    for after in 'A'..='D' {
+        for channel in 1..=72 {
+            assert!(pwb_pad_position(
+                0,
+                AfterId::try_from(after).unwrap(),
+                PadChannelId::try_from(channel).unwrap()
+            )
+            .is_ok());
+        }
+    }
+}
+
+#[test]
+fn pwb_pad_position_correctness() {
+    for (row, channel) in (19..=36).rev().enumerate() {
+        assert_eq!(
+            pwb_pad_position(
+                0,
+                AfterId::try_from('A').unwrap(),
+                PadChannelId::try_from(channel).unwrap()
+            )
+            .unwrap(),
+            PwbPadPosition {
+                column: PwbPadColumn(0),
+                row: PwbPadRow(row),
+            }
+        );
+    }
+    for (row, channel) in (37..=54).rev().enumerate() {
+        assert_eq!(
+            pwb_pad_position(
+                0,
+                AfterId::try_from('A').unwrap(),
+                PadChannelId::try_from(channel).unwrap()
+            )
+            .unwrap(),
+            PwbPadPosition {
+                column: PwbPadColumn(0),
+                row: PwbPadRow(row + 18),
+            }
+        );
+    }
+    for (row, channel) in (19..=36).rev().enumerate() {
+        assert_eq!(
+            pwb_pad_position(
+                0,
+                AfterId::try_from('B').unwrap(),
+                PadChannelId::try_from(channel).unwrap()
+            )
+            .unwrap(),
+            PwbPadPosition {
+                column: PwbPadColumn(0),
+                row: PwbPadRow(row + 36),
+            }
+        );
+    }
+    for (row, channel) in (37..=54).rev().enumerate() {
+        assert_eq!(
+            pwb_pad_position(
+                0,
+                AfterId::try_from('B').unwrap(),
+                PadChannelId::try_from(channel).unwrap()
+            )
+            .unwrap(),
+            PwbPadPosition {
+                column: PwbPadColumn(0),
+                row: PwbPadRow(row + 54),
+            }
+        );
+    }
+    for (row, channel) in (1..=18).enumerate() {
+        assert_eq!(
+            pwb_pad_position(
+                0,
+                AfterId::try_from('A').unwrap(),
+                PadChannelId::try_from(channel).unwrap()
+            )
+            .unwrap(),
+            PwbPadPosition {
+                column: PwbPadColumn(1),
+                row: PwbPadRow(row),
+            }
+        );
+    }
+    for (row, channel) in (55..=72).enumerate() {
+        assert_eq!(
+            pwb_pad_position(
+                0,
+                AfterId::try_from('A').unwrap(),
+                PadChannelId::try_from(channel).unwrap()
+            )
+            .unwrap(),
+            PwbPadPosition {
+                column: PwbPadColumn(1),
+                row: PwbPadRow(row + 18),
+            }
+        );
+    }
+    for (row, channel) in (1..=18).enumerate() {
+        assert_eq!(
+            pwb_pad_position(
+                0,
+                AfterId::try_from('B').unwrap(),
+                PadChannelId::try_from(channel).unwrap()
+            )
+            .unwrap(),
+            PwbPadPosition {
+                column: PwbPadColumn(1),
+                row: PwbPadRow(row + 36),
+            }
+        );
+    }
+    for (row, channel) in (55..=72).enumerate() {
+        assert_eq!(
+            pwb_pad_position(
+                0,
+                AfterId::try_from('B').unwrap(),
+                PadChannelId::try_from(channel).unwrap()
+            )
+            .unwrap(),
+            PwbPadPosition {
+                column: PwbPadColumn(1),
+                row: PwbPadRow(row + 54),
+            }
+        );
+    }
+    for (row, channel) in (55..=72).rev().enumerate() {
+        assert_eq!(
+            pwb_pad_position(
+                0,
+                AfterId::try_from('D').unwrap(),
+                PadChannelId::try_from(channel).unwrap()
+            )
+            .unwrap(),
+            PwbPadPosition {
+                column: PwbPadColumn(2),
+                row: PwbPadRow(row),
+            }
+        );
+    }
+    for (row, channel) in (1..=18).rev().enumerate() {
+        assert_eq!(
+            pwb_pad_position(
+                0,
+                AfterId::try_from('D').unwrap(),
+                PadChannelId::try_from(channel).unwrap()
+            )
+            .unwrap(),
+            PwbPadPosition {
+                column: PwbPadColumn(2),
+                row: PwbPadRow(row + 18),
+            }
+        );
+    }
+    for (row, channel) in (55..=72).rev().enumerate() {
+        assert_eq!(
+            pwb_pad_position(
+                0,
+                AfterId::try_from('C').unwrap(),
+                PadChannelId::try_from(channel).unwrap()
+            )
+            .unwrap(),
+            PwbPadPosition {
+                column: PwbPadColumn(2),
+                row: PwbPadRow(row + 36),
+            }
+        );
+    }
+    for (row, channel) in (1..=18).rev().enumerate() {
+        assert_eq!(
+            pwb_pad_position(
+                0,
+                AfterId::try_from('C').unwrap(),
+                PadChannelId::try_from(channel).unwrap()
+            )
+            .unwrap(),
+            PwbPadPosition {
+                column: PwbPadColumn(2),
+                row: PwbPadRow(row + 54),
+            }
+        );
+    }
+    for (row, channel) in (37..=54).enumerate() {
+        assert_eq!(
+            pwb_pad_position(
+                0,
+                AfterId::try_from('D').unwrap(),
+                PadChannelId::try_from(channel).unwrap()
+            )
+            .unwrap(),
+            PwbPadPosition {
+                column: PwbPadColumn(3),
+                row: PwbPadRow(row),
+            }
+        );
+    }
+    for (row, channel) in (19..=36).enumerate() {
+        assert_eq!(
+            pwb_pad_position(
+                0,
+                AfterId::try_from('D').unwrap(),
+                PadChannelId::try_from(channel).unwrap()
+            )
+            .unwrap(),
+            PwbPadPosition {
+                column: PwbPadColumn(3),
+                row: PwbPadRow(row + 18),
+            }
+        );
+    }
+    for (row, channel) in (37..=54).enumerate() {
+        assert_eq!(
+            pwb_pad_position(
+                0,
+                AfterId::try_from('C').unwrap(),
+                PadChannelId::try_from(channel).unwrap()
+            )
+            .unwrap(),
+            PwbPadPosition {
+                column: PwbPadColumn(3),
+                row: PwbPadRow(row + 36),
+            }
+        );
+    }
+    for (row, channel) in (19..=36).enumerate() {
+        assert_eq!(
+            pwb_pad_position(
+                0,
+                AfterId::try_from('C').unwrap(),
+                PadChannelId::try_from(channel).unwrap()
+            )
+            .unwrap(),
+            PwbPadPosition {
+                column: PwbPadColumn(3),
+                row: PwbPadRow(row + 54),
+            }
+        );
+    }
+}

--- a/detector/src/padwing/map/tests.rs
+++ b/detector/src/padwing/map/tests.rs
@@ -1,0 +1,128 @@
+use super::*;
+use crate::padwing::BoardId;
+use crate::padwing::PADWING_BOARDS;
+
+#[test]
+fn try_from_index_tpc_pwb_column() {
+    for i in 0..=7 {
+        assert_eq!(TpcPwbColumn::try_from(i).unwrap(), TpcPwbColumn(i));
+    }
+    for i in 8..=19000 {
+        assert!(TpcPwbColumn::try_from(i).is_err());
+    }
+}
+
+#[test]
+fn try_from_index_tpc_pwb_row() {
+    for i in 0..=7 {
+        assert_eq!(TpcPwbRow::try_from(i).unwrap(), TpcPwbRow(i));
+    }
+    for i in 8..=19000 {
+        assert!(TpcPwbRow::try_from(i).is_err());
+    }
+}
+
+#[test]
+fn tpc_pwb_position_column() {
+    for i in 0..=7 {
+        let position = TpcPwbPosition {
+            column: TpcPwbColumn(i),
+            row: TpcPwbRow(0),
+        };
+        assert_eq!(position.column(), TpcPwbColumn(i));
+    }
+}
+
+#[test]
+fn tpc_pwb_position_row() {
+    for i in 0..=7 {
+        let position = TpcPwbPosition {
+            column: TpcPwbColumn(0),
+            row: TpcPwbRow(i),
+        };
+        assert_eq!(position.row(), TpcPwbRow(i));
+    }
+}
+
+fn all_different_str(map: [[&str; 8]; 8]) -> bool {
+    for (i, row) in map.iter().enumerate() {
+        for (j, board) in row.iter().enumerate() {
+            for (k, row2) in map.iter().enumerate() {
+                for (l, board2) in row2.iter().enumerate() {
+                    if i == k && j == l {
+                        continue;
+                    }
+                    if board == board2 {
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+    true
+}
+
+#[test]
+fn all_different_str_in_padwing_boards_maps() {
+    assert!(all_different_str(PADWING_BOARDS_4418));
+}
+
+fn all_valid_str(map: [[&str; 8]; 8]) -> bool {
+    for row in map.iter() {
+        for name in row.iter() {
+            if BoardId::try_from(*name).is_err() {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+#[test]
+fn all_valid_str_in_padwing_boards_maps() {
+    assert!(all_valid_str(PADWING_BOARDS_4418));
+}
+
+// First index is column, second index is row.
+// The value is the board name.
+const REGRESSION_GATE_KEEPER_4418: [[&str; 8]; 8] = [
+    ["12", "13", "14", "02", "11", "17", "18", "19"],
+    ["20", "21", "22", "23", "24", "25", "26", "27"],
+    ["46", "29", "08", "77", "10", "33", "34", "35"],
+    ["36", "37", "01", "39", "76", "41", "42", "40"],
+    ["44", "49", "07", "78", "03", "04", "45", "15"],
+    ["52", "53", "54", "55", "56", "57", "58", "05"],
+    ["60", "00", "06", "63", "64", "65", "66", "67"],
+    ["68", "69", "70", "71", "72", "73", "74", "75"],
+];
+
+#[test]
+fn tpc_pwb_position_missing_map() {
+    for i in 0..4418 {
+        for (name, _mac, _id) in PADWING_BOARDS {
+            let board_id = BoardId::try_from(name).unwrap();
+            match tpc_pwb_position(i, board_id) {
+                Err(MapTpcPwbPositionError::MissingMap { run_number }) => assert_eq!(run_number, i),
+                _ => unreachable!(),
+            }
+        }
+    }
+}
+
+#[test]
+fn inverse_map_tpc_pwb_position_4418() {
+    for run_number in 4418..=10000 {
+        for (i, row) in REGRESSION_GATE_KEEPER_4418.iter().enumerate() {
+            for (j, board) in row.iter().enumerate() {
+                let position = TpcPwbPosition {
+                    column: TpcPwbColumn(i),
+                    row: TpcPwbRow(j),
+                };
+                assert_eq!(
+                    tpc_pwb_position(run_number, BoardId::try_from(*board).unwrap()).unwrap(),
+                    position
+                );
+            }
+        }
+    }
+}

--- a/detector/src/padwing/tests.rs
+++ b/detector/src/padwing/tests.rs
@@ -445,46 +445,96 @@ fn try_from_unsigned_trigger() {
 }
 
 #[test]
+fn try_from_unsigned_reset_channel_id() {
+    assert!(ResetChannelId::try_from(0).is_err());
+    for i in 1..=3 {
+        assert!(ResetChannelId::try_from(i).is_ok());
+    }
+    for i in 4..=u16::MAX {
+        assert!(ResetChannelId::try_from(i).is_err());
+    }
+}
+
+#[test]
+fn try_from_unsigned_fpn_channel_id() {
+    assert!(FpnChannelId::try_from(0).is_err());
+    for i in 1..=4 {
+        assert!(FpnChannelId::try_from(i).is_ok());
+    }
+    for i in 5..=u16::MAX {
+        assert!(FpnChannelId::try_from(i).is_err());
+    }
+}
+
+#[test]
+fn try_from_unsigned_pad_channel_id() {
+    assert!(PadChannelId::try_from(0).is_err());
+    for i in 1..=72 {
+        assert!(PadChannelId::try_from(i).is_ok());
+    }
+    for i in 73..=u16::MAX {
+        assert!(PadChannelId::try_from(i).is_err());
+    }
+}
+
+#[test]
 fn try_from_unsigned_channel_id() {
     assert!(ChannelId::try_from(0).is_err());
     for i in 1..=3 {
-        assert!(matches!(
+        assert_eq!(
             ChannelId::try_from(i).unwrap(),
-            ChannelId::Reset(_)
-        ));
+            ChannelId::Reset(ResetChannelId::try_from(i).unwrap())
+        );
     }
     for i in 4..=15 {
-        assert!(matches!(ChannelId::try_from(i).unwrap(), ChannelId::Pad(_)));
+        assert_eq!(
+            ChannelId::try_from(i).unwrap(),
+            ChannelId::Pad(PadChannelId::try_from(i - 3).unwrap())
+        );
     }
-    assert!(matches!(
+    assert_eq!(
         ChannelId::try_from(16).unwrap(),
-        ChannelId::Fpn(_)
-    ));
+        ChannelId::Fpn(FpnChannelId::try_from(1).unwrap())
+    );
     for i in 17..=28 {
-        assert!(matches!(ChannelId::try_from(i).unwrap(), ChannelId::Pad(_)));
+        assert_eq!(
+            ChannelId::try_from(i).unwrap(),
+            ChannelId::Pad(PadChannelId::try_from(i - 4).unwrap())
+        );
     }
-    assert!(matches!(
+    assert_eq!(
         ChannelId::try_from(29).unwrap(),
-        ChannelId::Fpn(_)
-    ));
+        ChannelId::Fpn(FpnChannelId::try_from(2).unwrap())
+    );
     for i in 30..=53 {
-        assert!(matches!(ChannelId::try_from(i).unwrap(), ChannelId::Pad(_)));
+        assert_eq!(
+            ChannelId::try_from(i).unwrap(),
+            ChannelId::Pad(PadChannelId::try_from(i - 5).unwrap())
+        );
     }
-    assert!(matches!(
+    assert_eq!(
         ChannelId::try_from(54).unwrap(),
-        ChannelId::Fpn(_)
-    ));
+        ChannelId::Fpn(FpnChannelId::try_from(3).unwrap())
+    );
     for i in 55..=66 {
-        assert!(matches!(ChannelId::try_from(i).unwrap(), ChannelId::Pad(_)));
+        assert_eq!(
+            ChannelId::try_from(i).unwrap(),
+            ChannelId::Pad(PadChannelId::try_from(i - 6).unwrap())
+        );
     }
-    assert!(matches!(
+    assert_eq!(
         ChannelId::try_from(67).unwrap(),
-        ChannelId::Fpn(_)
-    ));
+        ChannelId::Fpn(FpnChannelId::try_from(4).unwrap())
+    );
     for i in 68..=79 {
-        assert!(matches!(ChannelId::try_from(i).unwrap(), ChannelId::Pad(_)));
+        assert_eq!(
+            ChannelId::try_from(i).unwrap(),
+            ChannelId::Pad(PadChannelId::try_from(i - 7).unwrap())
+        );
     }
-    assert!(ChannelId::try_from(80).is_err());
+    for i in 80..=u16::MAX {
+        assert!(ChannelId::try_from(i).is_err());
+    }
 }
 
 const ODD_PWB_V2_PACKET: [u8; 104] = [

--- a/detector/src/padwing/tests.rs
+++ b/detector/src/padwing/tests.rs
@@ -8,8 +8,8 @@ fn padwing_rate() {
 
 #[test]
 fn padwing_boards() {
-    for (i, board) in PADWINGBOARDS.iter().enumerate() {
-        for other_board in PADWINGBOARDS.iter().skip(i + 1) {
+    for (i, board) in PADWING_BOARDS.iter().enumerate() {
+        for other_board in PADWING_BOARDS.iter().skip(i + 1) {
             assert_ne!(board.0, other_board.0);
             assert_ne!(board.1, other_board.1);
             assert_ne!(board.2, other_board.2);
@@ -19,7 +19,7 @@ fn padwing_boards() {
 
 #[test]
 fn bank_names_from_padwing_boards() {
-    for triplet in PADWINGBOARDS {
+    for triplet in PADWING_BOARDS {
         let bank_name = format!("PC{}", triplet.0);
         let bank_name = PadwingBankName::try_from(&bank_name[..]).unwrap();
         assert_eq!(bank_name.board_id(), BoardId::try_from(triplet.1).unwrap());
@@ -28,7 +28,7 @@ fn bank_names_from_padwing_boards() {
 
 #[test]
 fn board_id() {
-    for triplet in PADWINGBOARDS {
+    for triplet in PADWING_BOARDS {
         let from_name = BoardId::try_from(triplet.0).unwrap();
         let from_mac = BoardId::try_from(triplet.1).unwrap();
         let from_id = BoardId::try_from(triplet.2).unwrap();
@@ -94,7 +94,7 @@ Payload CRC-32C: 2677759098"
 #[test]
 fn chunk_good() {
     let mut good_chunk = CHUNK;
-    for triplet in PADWINGBOARDS {
+    for triplet in PADWING_BOARDS {
         good_chunk[0..4].copy_from_slice(&triplet.2.to_le_bytes()[..]);
         let crc = !crc32c::crc32c(&good_chunk[0..16]);
         good_chunk[16..20].copy_from_slice(&crc.to_le_bytes()[..]);
@@ -263,7 +263,7 @@ fn chunk_payload_crc_mismatch() {
 #[test]
 fn chunk_board_id() {
     let mut good_chunk = CHUNK;
-    for triplet in PADWINGBOARDS {
+    for triplet in PADWING_BOARDS {
         for num in 0..4 {
             good_chunk[0..4].copy_from_slice(&triplet.2.to_le_bytes()[..]);
             good_chunk[10] = num;
@@ -280,7 +280,7 @@ fn chunk_board_id() {
 #[test]
 fn chunk_packet_sequence() {
     let mut good_chunk = CHUNK;
-    for triplet in PADWINGBOARDS {
+    for triplet in PADWING_BOARDS {
         for num in 0..4 {
             good_chunk[0..4].copy_from_slice(&triplet.2.to_le_bytes()[..]);
             good_chunk[10] = num;
@@ -297,7 +297,7 @@ fn chunk_packet_sequence() {
 #[test]
 fn chunk_channel_sequence() {
     let mut good_chunk = CHUNK;
-    for triplet in PADWINGBOARDS {
+    for triplet in PADWING_BOARDS {
         for num in 0..4 {
             good_chunk[0..4].copy_from_slice(&triplet.2.to_le_bytes()[..]);
             good_chunk[10] = num;
@@ -314,7 +314,7 @@ fn chunk_channel_sequence() {
 #[test]
 fn chunk_after_id() {
     let mut good_chunk = CHUNK;
-    for triplet in PADWINGBOARDS {
+    for triplet in PADWING_BOARDS {
         for num in 0..4 {
             good_chunk[0..4].copy_from_slice(&triplet.2.to_le_bytes()[..]);
             good_chunk[10] = num;
@@ -331,7 +331,7 @@ fn chunk_after_id() {
 #[test]
 fn chunk_is_end_of_message() {
     let mut good_chunk = CHUNK;
-    for triplet in PADWINGBOARDS {
+    for triplet in PADWING_BOARDS {
         for num in 0..4 {
             good_chunk[0..4].copy_from_slice(&triplet.2.to_le_bytes()[..]);
             good_chunk[10] = num;
@@ -344,7 +344,7 @@ fn chunk_is_end_of_message() {
     }
 
     let mut good_chunk = CHUNK;
-    for triplet in PADWINGBOARDS {
+    for triplet in PADWING_BOARDS {
         for num in 0..4 {
             good_chunk[0..4].copy_from_slice(&triplet.2.to_le_bytes()[..]);
             good_chunk[10] = num;
@@ -372,7 +372,7 @@ fn chunk_chunk_id() {
 #[test]
 fn chunk_header_crc() {
     let mut good_chunk = CHUNK;
-    for triplet in PADWINGBOARDS {
+    for triplet in PADWING_BOARDS {
         for num in 0..4 {
             good_chunk[0..4].copy_from_slice(&triplet.2.to_le_bytes()[..]);
             good_chunk[10] = num;
@@ -389,7 +389,7 @@ fn chunk_header_crc() {
 #[test]
 fn chunk_payload() {
     let mut good_chunk = CHUNK;
-    for triplet in PADWINGBOARDS {
+    for triplet in PADWING_BOARDS {
         for num in 0..4 {
             good_chunk[0..4].copy_from_slice(&triplet.2.to_le_bytes()[..]);
             good_chunk[10] = num;
@@ -403,7 +403,7 @@ fn chunk_payload() {
 #[test]
 fn chunk_payload_crc() {
     let mut good_chunk = CHUNK;
-    for triplet in PADWINGBOARDS {
+    for triplet in PADWING_BOARDS {
         for num in 0..4 {
             good_chunk[0..4].copy_from_slice(&triplet.2.to_le_bytes()[..]);
             good_chunk[10] = num;
@@ -578,7 +578,7 @@ fn pwb_v2_good() {
         good_packet[3] = i;
         assert!(PwbV2Packet::try_from(&good_packet[..]).is_ok());
     }
-    for triplet in PADWINGBOARDS {
+    for triplet in PADWING_BOARDS {
         good_packet[4..10].copy_from_slice(&triplet.1[..]);
         assert!(PwbV2Packet::try_from(&good_packet[..]).is_ok());
     }
@@ -622,7 +622,7 @@ fn pwb_v2_good() {
         good_packet[3] = i;
         assert!(PwbV2Packet::try_from(&good_packet[..]).is_ok());
     }
-    for triplet in PADWINGBOARDS {
+    for triplet in PADWING_BOARDS {
         good_packet[4..10].copy_from_slice(&triplet.1[..]);
         assert!(PwbV2Packet::try_from(&good_packet[..]).is_ok());
     }
@@ -1179,7 +1179,7 @@ fn pwb_v2_packet_from_chunks_ok() {
 #[test]
 fn pwb_v2_packet_from_chunks_device_id_mismatch() {
     let mut chunk_zero = CHUNK_ZERO;
-    for triplet in PADWINGBOARDS {
+    for triplet in PADWING_BOARDS {
         if BoardId::try_from(triplet.2).unwrap() == BoardId::try_from("00").unwrap() {
             continue;
         }
@@ -1201,7 +1201,7 @@ fn pwb_v2_packet_from_chunks_device_id_mismatch() {
     }
 
     let mut chunk_one = CHUNK_ONE;
-    for triplet in PADWINGBOARDS {
+    for triplet in PADWING_BOARDS {
         if BoardId::try_from(triplet.2).unwrap() == BoardId::try_from("00").unwrap() {
             continue;
         }
@@ -1223,7 +1223,7 @@ fn pwb_v2_packet_from_chunks_device_id_mismatch() {
     }
 
     let mut chunk_two = CHUNK_TWO;
-    for triplet in PADWINGBOARDS {
+    for triplet in PADWING_BOARDS {
         if BoardId::try_from(triplet.2).unwrap() == BoardId::try_from("00").unwrap() {
             continue;
         }


### PR DESCRIPTION
Include all the machinery required to map a pad signal to a rTPC location.

This introduces:
- `TpcPwbPosition`: The position of a PWB board within the TPC. Mapped from the `run_number` and `BoardId`.
- `PwbPadPosition`: The position of a pad within a PWB. Mapped from `AfterId` and `PadChannelId`; I also made this mapping to depend on the `run_number` to keep consistency with the anode wire channel mapping. This is unlikely to ever change/depend on run number, but if it does, it just makes things easier. Keeping a constant API between wires and pads is also beneficial.
- `TpcPadPosition`: The position of a pad within the TPC. Mapped from the above.