### PR TITLE
Wire gain calibration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,7 @@ version = "0.2.0"
 dependencies = [
  "alpha_g_detector",
  "anyhow",
+ "argmin",
  "clap",
  "cursive",
  "glob",
@@ -60,6 +61,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "argmin"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897c18cfe995220bdd94a27455e5afedc7c688cbf62ad2be88ce7552452aa1b2"
+dependencies = [
+ "anyhow",
+ "argmin-math",
+ "instant",
+ "num-traits",
+ "paste",
+ "rand",
+ "rand_xoshiro",
+ "thiserror",
+]
+
+[[package]]
+name = "argmin-math"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8798ca7447753fcb3dd98d9095335b1564812a68c6e7c3d1926e1d5cf094e37"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rand",
+ "thiserror",
 ]
 
 [[package]]
@@ -750,6 +782,15 @@ checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
  "rand",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]

--- a/analysis/Cargo.toml
+++ b/analysis/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["science", "command-line-utilities"]
 [dependencies]
 alpha_g_detector = { version = "0.2",  path = "../detector" }
 anyhow = "1"
+argmin = { version = "0.8.1", default-features = false }
 clap = { version = "4", features = ["derive"] }
 cursive = "0.20"
 glob = "0.3"

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -27,11 +27,14 @@ Visualize the rate of the TRG scalers for a single run.
 
 #### Anode Wires
 
+- [`alpha-g-wire-noise-statistics`](src/bin/alpha-g-wire-noise-statistics/README.md):
+Statistical analysis of the anode wire signals during a noise run.
 - [`alpha-g-wire-baseline-comparison`](src/bin/alpha-g-wire-baseline-comparison/README.md):
 Compare anode wire baseline calibration files to determine if there is a
 statistically significant difference between them.
-- [`alpha-g-wire-noise-statistics`](src/bin/alpha-g-wire-noise-statistics/README.md):
-Statistical analysis of the anode wire signals during a noise run.
+- [`alpha-g-wire-gain-calibration`](src/bin/alpha-g-wire-gain-calibration/README.md):
+Gain calibration of the anode wire signals.
+
 
 ### Other
 

--- a/analysis/src/bin/alpha-g-wire-gain-calibration/README.md
+++ b/analysis/src/bin/alpha-g-wire-gain-calibration/README.md
@@ -1,0 +1,26 @@
+# `alpha-g-wire-gain-calibration`
+
+Gain calibration of the anode wire signals. Run the
+`alpha-g-wire-gain-calibration --help` command to make sure you have installed
+the `alpha-g-analysis` package and print help information.
+
+## Requirements
+
+Please make sure you have all the following installed in your system, otherwise
+`alpha-g-wire-gain-calibration` may not work as expected:
+
+- pdflatex: Access to the `pdflatex` command. Additionally, the `standalone` and
+`pgfplots` packages are required to generate the plots. To make sure that these
+are installed properly, run:
+	```
+	pdflatex "\documentclass{standalone}\usepackage{pgfplots}\begin{document}\begin{tikzpicture}\begin{axis}\end{axis}\end{tikzpicture}\end{document}"
+	```
+	If successful, this will create a PDF file with an empty plot in the current
+working directory.
+- Default PDF viewer: Use `xdg-mime` to configure the appropriate default PDF
+ viewer ([example instructions for zathura](https://wiki.archlinux.org/title/zathura#Make_zathura_the_default_pdf_viewer)).
+To make sure that this is configured correctly run:
+	```
+	xdg-open any_pdf_document_on_your_system.pdf
+	```
+	This should open the PDF with the desired viewer.

--- a/analysis/src/bin/alpha-g-wire-gain-calibration/distribution.rs
+++ b/analysis/src/bin/alpha-g-wire-gain-calibration/distribution.rs
@@ -98,7 +98,7 @@ impl Distribution {
 }
 
 pub(crate) struct CumulativeDistribution {
-    samples: Vec<f64>,
+    pub(crate) samples: Vec<f64>,
 }
 
 impl CumulativeDistribution {

--- a/analysis/src/bin/alpha-g-wire-gain-calibration/distribution.rs
+++ b/analysis/src/bin/alpha-g-wire-gain-calibration/distribution.rs
@@ -1,5 +1,6 @@
 use alpha_g_detector::alpha16::{ADC_MAX, ADC_MIN};
 
+#[derive(Clone, Debug)]
 pub(crate) struct Distribution {
     samples: Vec<usize>,
 }
@@ -28,25 +29,109 @@ impl Distribution {
         self.samples[index] += multiplicity;
     }
     /// Re-scale the samples with a given factor.
-    pub(crate) fn rescale(&self, factor: f64) -> Self {
+    pub(crate) fn rescale(self, factor: f64) -> Self {
         // Sample that corresponds to index 0
         let min = i32::from(ADC_MIN) - i32::from(ADC_MAX);
 
         let mut scaled = Self::new();
         for (index, count) in self
             .samples
-            .iter()
+            .into_iter()
             .enumerate()
-            .filter(|(_, count)| **count > 0)
+            .filter(|(_, count)| *count > 0)
         {
             let sample = min + index as i32;
             let scaled_sample = f64::from(sample) * factor;
 
-            // Add `count` samples to the scaled distribution
-            scaled.add_sample(scaled_sample.round() as i32, *count);
+            scaled.add_sample(scaled_sample.round() as i32, count);
         }
 
         scaled
+    }
+    /// Saturate the distribution at a given threshold.
+    /// All samples greater than the `positive_threshold` will be set to
+    /// `positive_threshold`.
+    /// All samples less than the `negative_threshold` will be set to
+    /// `negative_threshold`.
+    pub(crate) fn saturate(self, negative_threshold: i32, positive_threshold: i32) -> Self {
+        // Sample that corresponds to index 0
+        let min = i32::from(ADC_MIN) - i32::from(ADC_MAX);
+
+        let mut saturated = Self::new();
+        for (index, count) in self
+            .samples
+            .into_iter()
+            .enumerate()
+            .filter(|(_, count)| *count > 0)
+        {
+            let sample = min + index as i32;
+            let sample = sample.clamp(negative_threshold, positive_threshold);
+
+            saturated.add_sample(sample, count);
+        }
+        saturated
+    }
+    /// Suppress the distribution at a given threshold.
+    /// All samples between -`threshold` and +`threshold` (inclusive) will be
+    /// suppressed.
+    pub(crate) fn suppress(self, threshold: i32) -> Self {
+        // Sample that corresponds to index 0
+        let min = i32::from(ADC_MIN) - i32::from(ADC_MAX);
+
+        let threshold = threshold.abs();
+        let mut suppressed = Self::new();
+        for (index, count) in self
+            .samples
+            .into_iter()
+            .enumerate()
+            .filter(|(_, count)| *count > 0)
+        {
+            let sample = min + index as i32;
+            if sample.abs() <= threshold {
+                continue;
+            }
+
+            suppressed.add_sample(sample, count);
+        }
+        suppressed
+    }
+}
+
+pub(crate) struct CumulativeDistribution {
+    samples: Vec<f64>,
+}
+
+impl CumulativeDistribution {
+    /// Create a cumulative distribution from a distribution.
+    // The distribution only has raw counts, so we need to first accumulate
+    // the counts, and then normalize.
+    pub(crate) fn from_distribution(distribution: &Distribution) -> Self {
+        let mut samples = Vec::with_capacity(distribution.samples.len());
+        let mut sum = 0;
+        for count in distribution.samples.iter() {
+            sum += count;
+            samples.push(sum);
+        }
+
+        let total = samples.last().copied().unwrap_or(0);
+        let samples = samples
+            .into_iter()
+            .map(|count| count as f64 / total as f64)
+            .collect();
+
+        Self { samples }
+    }
+    /// Calculate the Kolmogorov-Smirnov distance between two cumulative
+    /// distributions.
+    pub(crate) fn ks_distance(&self, other: &Self) -> f64 {
+        let mut max_distance = 0.0;
+        for (self_sample, other_sample) in self.samples.iter().zip(other.samples.iter()) {
+            let distance = (self_sample - other_sample).abs();
+            if distance > max_distance {
+                max_distance = distance;
+            }
+        }
+        max_distance
     }
 }
 

--- a/analysis/src/bin/alpha-g-wire-gain-calibration/distribution.rs
+++ b/analysis/src/bin/alpha-g-wire-gain-calibration/distribution.rs
@@ -112,11 +112,19 @@ impl CumulativeDistribution {
             sum += count;
             samples.push(sum);
         }
-
-        let total = samples.last().copied().unwrap_or(0);
+        // Normalize only if there were samples. Otherwise, leave the cumulative
+        // distribution all zeros.
+        // It could be argued that a cumulative distribution with all zeros
+        // doesn't make sense, but it is completely valid in this context.
+        // Such cumulative distribution could show up when all values in the
+        // distribution are suppressed.
+        // Additionally, the KS distance between such cumulative distribution
+        // and a normal (correct) cumulative distribution is 1, which is
+        // definitely not the minimum KS distance.
+        let normalization = if sum > 0 { sum as f64 } else { 1.0 };
         let samples = samples
             .into_iter()
-            .map(|count| count as f64 / total as f64)
+            .map(|sample| sample as f64 / normalization)
             .collect();
 
         Self { samples }

--- a/analysis/src/bin/alpha-g-wire-gain-calibration/distribution.rs
+++ b/analysis/src/bin/alpha-g-wire-gain-calibration/distribution.rs
@@ -1,0 +1,54 @@
+use alpha_g_detector::alpha16::{ADC_MAX, ADC_MIN};
+
+pub(crate) struct Distribution {
+    samples: Vec<usize>,
+}
+
+impl Distribution {
+    /// Create a new empty distribution.
+    pub(crate) fn new() -> Self {
+        // The minimum possible amplitude value is ADC_MIN - ADC_MAX.
+        // The maximum possible amplitude value is ADC_MAX - ADC_MIN.
+        // Therefore, the number of possible amplitude values is
+        // 2 * (ADC_MAX - ADC_MIN) + 1
+        Self {
+            // Need to cast to i32 to avoid overflow
+            samples: vec![0; (2 * (i32::from(ADC_MAX) - i32::from(ADC_MIN)) + 1) as usize],
+        }
+    }
+    /// Add a sample to the distribution.
+    /// The sample is expected to be in the range [ADC_MIN - ADC_MAX, ADC_MAX - ADC_MIN].
+    /// If the sample is outside this range, it will be clamped to the range.
+    pub(crate) fn add_sample(&mut self, sample: i32, multiplicity: usize) {
+        let min = i32::from(ADC_MIN) - i32::from(ADC_MAX);
+        let max = i32::from(ADC_MAX) - i32::from(ADC_MIN);
+        let sample = sample.clamp(min, max);
+        // The minimum value corresponds to index 0
+        let index = (sample - min) as usize;
+        self.samples[index] += multiplicity;
+    }
+    /// Re-scale the samples with a given factor.
+    pub(crate) fn rescale(&self, factor: f64) -> Self {
+        // Sample that corresponds to index 0
+        let min = i32::from(ADC_MIN) - i32::from(ADC_MAX);
+
+        let mut scaled = Self::new();
+        for (index, count) in self
+            .samples
+            .iter()
+            .enumerate()
+            .filter(|(_, count)| **count > 0)
+        {
+            let sample = min + index as i32;
+            let scaled_sample = f64::from(sample) * factor;
+
+            // Add `count` samples to the scaled distribution
+            scaled.add_sample(scaled_sample.round() as i32, *count);
+        }
+
+        scaled
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/analysis/src/bin/alpha-g-wire-gain-calibration/distribution/tests.rs
+++ b/analysis/src/bin/alpha-g-wire-gain-calibration/distribution/tests.rs
@@ -131,6 +131,10 @@ fn cumulative_distribution_from_distribution() {
     assert_eq!(c.samples[0], 0.5);
     assert_eq!(c.samples[2 * (max - min) as usize - 1], 0.5);
     assert_eq!(c.samples[2 * (max - min) as usize], 1.0);
+
+    let d = Distribution::new();
+    let c = CumulativeDistribution::from_distribution(&d);
+    assert_eq!(c.samples.iter().sum::<f64>(), 0.0);
 }
 
 #[test]

--- a/analysis/src/bin/alpha-g-wire-gain-calibration/distribution/tests.rs
+++ b/analysis/src/bin/alpha-g-wire-gain-calibration/distribution/tests.rs
@@ -1,0 +1,65 @@
+use super::*;
+
+#[test]
+fn new_empty_distribution() {
+    let d = Distribution::new();
+    assert_eq!(
+        d.samples.len(),
+        (2 * (i32::from(ADC_MAX) - i32::from(ADC_MIN)) + 1) as usize
+    );
+    assert_eq!(d.samples.iter().sum::<usize>(), 0);
+}
+
+#[test]
+fn distribution_add_samples() {
+    let min = i32::from(ADC_MIN);
+    let max = i32::from(ADC_MAX);
+
+    let mut d = Distribution::new();
+    d.add_sample(min - max, 1);
+    assert_eq!(d.samples[0], 1);
+    assert_eq!(d.samples.iter().sum::<usize>(), 1);
+
+    d.add_sample(min - max - 1, 5);
+    assert_eq!(d.samples[0], 6);
+    assert_eq!(d.samples.iter().sum::<usize>(), 6);
+
+    d.add_sample(max - min, 1);
+    assert_eq!(d.samples.last().unwrap(), &1);
+    assert_eq!(d.samples.iter().sum::<usize>(), 7);
+
+    d.add_sample(max - min + 1, 5);
+    assert_eq!(d.samples.last().unwrap(), &6);
+    assert_eq!(d.samples.iter().sum::<usize>(), 12);
+
+    d.add_sample(0, 1000);
+    assert_eq!(d.samples[(max - min) as usize], 1000);
+    assert_eq!(d.samples.iter().sum::<usize>(), 1012);
+}
+
+#[test]
+fn distribution_rescale() {
+    let min = i32::from(ADC_MIN);
+    let max = i32::from(ADC_MAX);
+
+    let mut d = Distribution::new();
+    d.add_sample(0, 1000);
+    d.add_sample(1, 1010);
+    d.add_sample(-1, 990);
+
+    let rescaled = d.rescale(2.0);
+    assert_eq!(rescaled.samples[(max - min) as usize], 1000);
+    assert_eq!(rescaled.samples[(max - min + 2) as usize], 1010);
+    assert_eq!(rescaled.samples[(max - min - 2) as usize], 990);
+    assert_eq!(rescaled.samples.iter().sum::<usize>(), 3000);
+
+    let rescaled = d.rescale(0.45);
+    assert_eq!(rescaled.samples[(max - min) as usize], 3000);
+    assert_eq!(rescaled.samples.iter().sum::<usize>(), 3000);
+
+    let rescaled = d.rescale(1000000000.0);
+    assert_eq!(rescaled.samples[(max - min) as usize], 1000);
+    assert_eq!(rescaled.samples[0], 990);
+    assert_eq!(rescaled.samples.last().unwrap(), &1010);
+    assert_eq!(rescaled.samples.iter().sum::<usize>(), 3000);
+}

--- a/analysis/src/bin/alpha-g-wire-gain-calibration/distribution/tests.rs
+++ b/analysis/src/bin/alpha-g-wire-gain-calibration/distribution/tests.rs
@@ -47,19 +47,134 @@ fn distribution_rescale() {
     d.add_sample(1, 1010);
     d.add_sample(-1, 990);
 
-    let rescaled = d.rescale(2.0);
+    let rescaled = d.clone().rescale(2.0);
     assert_eq!(rescaled.samples[(max - min) as usize], 1000);
     assert_eq!(rescaled.samples[(max - min + 2) as usize], 1010);
     assert_eq!(rescaled.samples[(max - min - 2) as usize], 990);
     assert_eq!(rescaled.samples.iter().sum::<usize>(), 3000);
 
-    let rescaled = d.rescale(0.45);
+    let rescaled = d.clone().rescale(0.45);
     assert_eq!(rescaled.samples[(max - min) as usize], 3000);
     assert_eq!(rescaled.samples.iter().sum::<usize>(), 3000);
 
-    let rescaled = d.rescale(1000000000.0);
+    let rescaled = d.clone().rescale(1000000000.0);
     assert_eq!(rescaled.samples[(max - min) as usize], 1000);
     assert_eq!(rescaled.samples[0], 990);
     assert_eq!(rescaled.samples.last().unwrap(), &1010);
     assert_eq!(rescaled.samples.iter().sum::<usize>(), 3000);
+}
+
+#[test]
+fn distribution_saturate() {
+    let min = i32::from(ADC_MIN);
+    let max = i32::from(ADC_MAX);
+
+    let mut d = Distribution::new();
+    d.add_sample(-2, 10);
+    d.add_sample(-1, 100);
+    d.add_sample(0, 1000);
+    d.add_sample(1, 10000);
+    d.add_sample(2, 100000);
+
+    let saturated = d.clone().saturate(-20, 20);
+    assert_eq!(saturated.samples, d.samples);
+
+    let saturated = d.clone().saturate(-2, -1);
+    assert_eq!(saturated.samples[(max - min - 2) as usize], 10);
+    assert_eq!(saturated.samples[(max - min - 1) as usize], 111100);
+
+    let saturated = d.clone().saturate(1, 2);
+    assert_eq!(saturated.samples[(max - min + 1) as usize], 11110);
+    assert_eq!(saturated.samples[(max - min + 2) as usize], 100000);
+}
+
+#[test]
+fn distribution_suppression() {
+    let min = i32::from(ADC_MIN);
+    let max = i32::from(ADC_MAX);
+
+    let mut d = Distribution::new();
+    d.add_sample(-1, 10);
+    d.add_sample(0, 100);
+    d.add_sample(1, 1000);
+
+    let suppressed = d.clone().suppress(0);
+    assert_eq!(suppressed.samples[(max - min - 1) as usize], 10);
+    assert_eq!(suppressed.samples[(max - min) as usize], 0);
+    assert_eq!(suppressed.samples[(max - min + 1) as usize], 1000);
+
+    d.add_sample(-2, 5);
+    d.add_sample(2, 5000);
+
+    let suppressed = d.clone().suppress(1);
+    assert_eq!(suppressed.samples[(max - min - 2) as usize], 5);
+    assert_eq!(suppressed.samples[(max - min - 1) as usize], 0);
+    assert_eq!(suppressed.samples[(max - min) as usize], 0);
+    assert_eq!(suppressed.samples[(max - min + 1) as usize], 0);
+    assert_eq!(suppressed.samples[(max - min + 2) as usize], 5000);
+}
+
+#[test]
+fn cumulative_distribution_from_distribution() {
+    let min = i32::from(ADC_MIN);
+    let max = i32::from(ADC_MAX);
+
+    let mut d = Distribution::new();
+    d.add_sample(max - min, 1);
+
+    let c = CumulativeDistribution::from_distribution(&d);
+    assert_eq!(c.samples[2 * (max - min) as usize], 1.0);
+    assert_eq!(c.samples[2 * (max - min) as usize - 1], 0.0);
+
+    d.add_sample(min - max, 1);
+    let c = CumulativeDistribution::from_distribution(&d);
+    assert_eq!(c.samples[0], 0.5);
+    assert_eq!(c.samples[2 * (max - min) as usize - 1], 0.5);
+    assert_eq!(c.samples[2 * (max - min) as usize], 1.0);
+}
+
+#[test]
+fn cumulative_distribution_ks_distance() {
+    let min = i32::from(ADC_MIN);
+    let max = i32::from(ADC_MAX);
+
+    let mut d1 = Distribution::new();
+    d1.add_sample(max - min, 1);
+
+    let mut d2 = Distribution::new();
+    d2.add_sample(min - max, 1);
+
+    let c1 = CumulativeDistribution::from_distribution(&d1);
+    let c2 = CumulativeDistribution::from_distribution(&d2);
+
+    assert_eq!(c1.ks_distance(&c2), 1.0);
+    assert_eq!(c2.ks_distance(&c1), 1.0);
+
+    let d1 = Distribution::new();
+    let d2 = Distribution::new();
+
+    let c1 = CumulativeDistribution::from_distribution(&d1);
+    let c2 = CumulativeDistribution::from_distribution(&d2);
+
+    assert_eq!(c1.ks_distance(&c2), 0.0);
+    assert_eq!(c2.ks_distance(&c1), 0.0);
+
+    let mut d1 = Distribution::new();
+    d1.add_sample(max - min, 1);
+    d1.add_sample(min - max, 1);
+
+    let mut d2 = Distribution::new();
+    d2.add_sample(max - min, 2);
+    d2.add_sample(min - max, 1);
+
+    let c1 = CumulativeDistribution::from_distribution(&d1);
+    let c2 = CumulativeDistribution::from_distribution(&d2);
+
+    let ks_dis = c1.ks_distance(&c2);
+    let diff = (ks_dis - 1.0 / 6.0).abs();
+    assert!(diff < 1e-6);
+
+    let ks_dis = c2.ks_distance(&c1);
+    let diff = (ks_dis - 1.0 / 6.0).abs();
+    assert!(diff < 1e-6);
 }

--- a/analysis/src/bin/alpha-g-wire-gain-calibration/main.rs
+++ b/analysis/src/bin/alpha-g-wire-gain-calibration/main.rs
@@ -17,6 +17,8 @@ use std::path::PathBuf;
 
 // CDF and Kolmogorov-Smirnov distance implementation
 mod distribution;
+// Minimization of the KS distance implementation
+mod minimization;
 
 #[derive(Parser)]
 #[command(author, version)]

--- a/analysis/src/bin/alpha-g-wire-gain-calibration/main.rs
+++ b/analysis/src/bin/alpha-g-wire-gain-calibration/main.rs
@@ -1,0 +1,112 @@
+//! Gain calibration of the anode wires.
+
+use alpha_g_detector::alpha16::aw_map::TpcWirePosition;
+use anyhow::{bail, ensure, Context, Result};
+use clap::Parser;
+use memmap2::Mmap;
+use midasio::read::file::{initial_timestamp_unchecked, run_number_unchecked};
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[command(author, version)]
+#[command(about = "Gain calibration of the anode wires", long_about = None)]
+struct Args {
+    /// Baseline calibration JSON file
+    #[arg(short, long, value_parser(parse_baseline_file))]
+    baseline_calibration: HashMap<TpcWirePosition, i16>,
+    /// MIDAS files from the calibration run.
+    #[arg(required = true)]
+    files: Vec<PathBuf>,
+    /// Path where all output files will be saved into.
+    #[arg(short, long, default_value = "./", value_parser(parse_directory))]
+    output_path: PathBuf,
+    /// Print detailed information about errors (if any).
+    #[arg(short, long)]
+    verbose: bool,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let mmaps = try_valid_mmaps(args.files).context("invalid input file")?;
+    // It is safe to unwrap because this has already been checked in
+    // `try_valid_mmaps`.
+    let run_number = run_number_unchecked(&mmaps[0].1).unwrap();
+    Ok(())
+}
+
+/// Parse a baseline calibration file.
+/// The file is expected to be valid JSON, and should deserialize to a HashMap
+/// of TpcWirePosition to (f64, f64, usize).
+fn parse_baseline_file(s: &str) -> Result<HashMap<TpcWirePosition, i16>> {
+    let contents = std::fs::read(s).with_context(|| format!("failed to read `{s}`"))?;
+    let map: HashMap<TpcWirePosition, (f64, f64, usize)> = serde_json::from_slice(&contents)
+        .with_context(|| format!("failed to deserialize `{s}`"))?;
+
+    Ok(map
+        .into_iter()
+        .map(|(wire, (baseline, _, _))| (wire, baseline.round() as i16))
+        .collect())
+}
+
+/// Parse `--output-path` flag as valid directory
+fn parse_directory(s: &str) -> Result<PathBuf> {
+    let path: PathBuf = s.into();
+    if path.is_dir() {
+        Ok(path)
+    } else {
+        bail!(
+            "`{}` is not pointing to a directory on disk",
+            path.display()
+        )
+    }
+}
+
+/// Try to get a vector of valid memory maps from a collection of paths. Ensure
+/// that all the memory maps are valid:
+/// - All belong to the same run number.
+/// - There are no duplicates (by timestamp).
+// Do not validate the entire MIDAS format (here) because it is too expensive.
+// Instead, only validate the run number and the timestamp.
+//
+// Return tuple to keep some context about each memory map.
+// This is useful for error reporting.
+fn try_valid_mmaps(file_names: impl IntoIterator<Item = PathBuf>) -> Result<Vec<(PathBuf, Mmap)>> {
+    let mut run_number = None;
+    let mut timestamps = HashSet::new();
+
+    file_names
+        .into_iter()
+        .map(|path| {
+            let file = File::open(&path)
+                .with_context(|| format!("failed to open `{}`", path.display()))?;
+            let mmap = unsafe { Mmap::map(&file) }
+                .with_context(|| format!("failed to memory map `{}`", path.display()))?;
+
+            let current_run_number = run_number_unchecked(&mmap).with_context(|| {
+                format!("failed to read run number from `{}`", path.display())
+            })?;
+            if let Some(run_number) = run_number {
+                ensure!(
+                    run_number == current_run_number,
+                    "bad run number in `{}` (expected `{run_number}`, found `{current_run_number}`)",
+                    path.display()
+                );
+            } else {
+                run_number = Some(current_run_number);
+            }
+
+            let initial_timestamp = initial_timestamp_unchecked(&mmap).with_context(|| {
+                format!("failed to read initial timestamp from `{}`", path.display())
+            })?;
+            ensure!(
+                timestamps.insert(initial_timestamp),
+                "duplicate initial timestamp `{initial_timestamp}` in `{}`",
+                path.display()
+            );
+
+            Ok((path, mmap))
+        })
+        .collect()
+}

--- a/analysis/src/bin/alpha-g-wire-gain-calibration/main.rs
+++ b/analysis/src/bin/alpha-g-wire-gain-calibration/main.rs
@@ -9,6 +9,9 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::path::PathBuf;
 
+// CDF and Kolmogorov-Smirnov distance implementation
+mod distribution;
+
 #[derive(Parser)]
 #[command(author, version)]
 #[command(about = "Gain calibration of the anode wires", long_about = None)]

--- a/analysis/src/bin/alpha-g-wire-gain-calibration/minimization.rs
+++ b/analysis/src/bin/alpha-g-wire-gain-calibration/minimization.rs
@@ -59,7 +59,7 @@ impl CostFunction for Problem {
 /// Try to find the best rescaling factor for the free distribution. The best
 /// rescaling factor is the one that minimizes the Kolmogorov-Smirnov distance
 /// between the pivot and the free distribution.
-fn try_minimization(
+pub(crate) fn try_minimization(
     pivot: &Distribution,
     free: &Distribution,
     negative_saturation: i32,

--- a/analysis/src/bin/alpha-g-wire-gain-calibration/minimization.rs
+++ b/analysis/src/bin/alpha-g-wire-gain-calibration/minimization.rs
@@ -1,0 +1,99 @@
+use crate::distribution::{CumulativeDistribution, Distribution};
+use anyhow::Context;
+use argmin::core::{CostFunction, Error, Executor, IterState};
+use argmin::solver::brent::BrentOpt;
+
+struct Problem {
+    // Pivot is the target cumulative distribution. Store as a cumulative
+    // distribution instead of a distribution to avoid recomputing every
+    // iteration.
+    pivot: CumulativeDistribution,
+    free: Distribution,
+    // To get the best estimate of the gain possible, we want both distributions
+    // to saturate and be suppressed at the same amplitudes.
+    negative_saturation: i32,
+    positive_saturation: i32,
+    suppression_threshold: i32,
+}
+
+impl Problem {
+    fn new(
+        pivot: Distribution,
+        free: Distribution,
+        negative_saturation: i32,
+        positive_saturation: i32,
+        suppression_threshold: i32,
+    ) -> Self {
+        let pivot = pivot
+            .saturate(negative_saturation, positive_saturation)
+            .suppress(suppression_threshold);
+        let pivot = CumulativeDistribution::from_distribution(&pivot);
+
+        Self {
+            pivot,
+            free,
+            negative_saturation,
+            positive_saturation,
+            suppression_threshold,
+        }
+    }
+}
+
+impl CostFunction for Problem {
+    type Param = f64;
+    type Output = f64;
+
+    fn cost(&self, p: &Self::Param) -> Result<Self::Output, Error> {
+        let free = self
+            .free
+            .clone()
+            .rescale(*p)
+            .saturate(self.negative_saturation, self.positive_saturation)
+            .suppress(self.suppression_threshold);
+        let free = CumulativeDistribution::from_distribution(&free);
+
+        Ok(self.pivot.ks_distance(&free))
+    }
+}
+
+/// Try to find the best rescaling factor for the free distribution. The best
+/// rescaling factor is the one that minimizes the Kolmogorov-Smirnov distance
+/// between the pivot and the free distribution.
+fn try_minimization(
+    pivot: &Distribution,
+    free: &Distribution,
+    negative_saturation: i32,
+    positive_saturation: i32,
+    suppression_threshold: i32,
+    initial_rescale_factor: f64,
+) -> Result<IterState<f64, (), (), (), f64>, Error> {
+    let problem = Problem::new(
+        pivot.clone(),
+        free.clone(),
+        negative_saturation,
+        positive_saturation,
+        suppression_threshold,
+    );
+    // With Brent's method I need to provide a `lower_bound` and an
+    // `upper_bound`. The minimization problem we are trying to solve here has
+    // a logical lower bound of 0.0 (the free distribution should not be
+    // rescaled to a negative value).
+    // The upper bound is a bit more tricky. The typical value for the
+    // data suppression threshold in anode wire waveforms is approximately
+    // 1500. The range of the waveform is approximately between [i16::MIN,
+    // i16::MAX]. Then a scaling factor of 10 corresponds to an equivalent
+    // suppression of 15000 in another wire. This is already excessive, so any
+    // value above 10 is not even worth dealing with (at that point it might
+    // be better to mask that wire).
+    let solver = BrentOpt::new(0.0, 10.0);
+
+    let res = Executor::new(problem, solver)
+        .configure(|state| state.param(initial_rescale_factor).target_cost(0.0))
+        .run()
+        .context("failed to run minimization executor")?;
+
+    Ok(res.state)
+}
+
+#[cfg(test)]
+mod tests;

--- a/analysis/src/bin/alpha-g-wire-gain-calibration/minimization/tests.rs
+++ b/analysis/src/bin/alpha-g-wire-gain-calibration/minimization/tests.rs
@@ -4,7 +4,7 @@ use super::*;
 fn minimization_try_minimization() {
     let mut d1 = Distribution::new();
     for sample in -10000..0 {
-        d1.add_sample(sample, sample.abs() as usize);
+        d1.add_sample(sample, sample.unsigned_abs() as usize);
     }
     for sample in 0..10000 {
         d1.add_sample(sample, sample as usize);

--- a/analysis/src/bin/alpha-g-wire-gain-calibration/minimization/tests.rs
+++ b/analysis/src/bin/alpha-g-wire-gain-calibration/minimization/tests.rs
@@ -1,0 +1,28 @@
+use super::*;
+
+#[test]
+fn minimization_try_minimization() {
+    let mut d1 = Distribution::new();
+    for sample in -10000..0 {
+        d1.add_sample(sample, sample.abs() as usize);
+    }
+    for sample in 0..10000 {
+        d1.add_sample(sample, sample as usize);
+    }
+
+    let d2 = d1.clone().rescale(0.5);
+    let best_param = try_minimization(&d1, &d2, -20000, 20000, 0, 1.0)
+        .unwrap()
+        .best_param
+        .unwrap();
+    let diff = (best_param - 1.0 / 0.5).abs();
+    assert!(diff < 0.0001);
+
+    let d2 = d1.clone().rescale(2.0);
+    let best_param = try_minimization(&d1, &d2, -20000, 20000, 0, 1.0)
+        .unwrap()
+        .best_param
+        .unwrap();
+    let diff = (best_param - 1.0 / 2.0).abs();
+    assert!(diff < 0.0001);
+}

--- a/analysis/src/bin/alpha-g-wire-gain-calibration/plot.rs
+++ b/analysis/src/bin/alpha-g-wire-gain-calibration/plot.rs
@@ -1,0 +1,27 @@
+use crate::distribution::CumulativeDistribution;
+use alpha_g_detector::alpha16::{ADC_MAX, ADC_MIN};
+use pgfplots::axis::plot::*;
+
+impl CumulativeDistribution {
+    /// Return a plot of the cumulative distribution.
+    // `num_coordinates` is the number of equally spaced coordinates to use
+    // between the last 0.0 and the first 1.0.
+    pub(crate) fn plot(&self, num_coordinates: usize) -> Plot2D {
+        let min = i32::from(ADC_MIN) - i32::from(ADC_MAX);
+
+        let mut plot = Plot2D::new();
+        let coordinates = self
+            .samples
+            .iter()
+            .enumerate()
+            // A LOT of the samples at the beginning are 0.0, and a LOT of the
+            // samples at the end are 1.0. We don't care about plotting those.
+            .filter(|&(_, &value)| value > 0.0 && value < 1.0)
+            .map(|(index, value)| (f64::from(min + index as i32), *value).into());
+        // We want only `num_coordinates`
+        let step = (coordinates.clone().count() - 1) / (num_coordinates - 1);
+        plot.coordinates = coordinates.step_by(step).collect();
+
+        plot
+    }
+}

--- a/analysis/src/bin/alpha-g-wire-gain-calibration/plot.rs
+++ b/analysis/src/bin/alpha-g-wire-gain-calibration/plot.rs
@@ -18,9 +18,12 @@ impl CumulativeDistribution {
             // samples at the end are 1.0. We don't care about plotting those.
             .filter(|&(_, &value)| value > 0.0 && value < 1.0)
             .map(|(index, value)| (f64::from(min + index as i32), *value).into());
-        // We want only `num_coordinates`
-        let step = (coordinates.clone().count() - 1) / (num_coordinates - 1);
-        plot.coordinates = coordinates.step_by(step).collect();
+        // We want only `num_coordinates`. Or if the cumulative distribution
+        // is empty, just leave the plot empty.
+        let step = coordinates.clone().count().saturating_sub(1) / (num_coordinates - 1);
+        if step > 0 {
+            plot.coordinates = coordinates.step_by(step).collect();
+        }
 
         plot
     }


### PR DESCRIPTION
Implement the `alpha-g-wire-gain-calibration` binary. This program generates a JSON file with the serialized gain corrections for each wire channel. It is also possible to compare a previous calibration with the current data.