### PR TITLE
PWB Baseline calibration

### DIFF
--- a/analysis/README.md
+++ b/analysis/README.md
@@ -38,6 +38,9 @@ Gain calibration of the anode wire signals.
 #### Pads
 - [`alpha-g-pad-noise-statistics`](src/bin/alpha-g-pad-noise-statistics/README.md):
 Statistical analysis of the pad signals during a noise run.
+- [`alpha-g-pad-baseline-comparison`](src/bin/alpha-g-pad-baseline-comparison/README.md):
+Compare pad baseline calibration files to determine if there is a statistically
+significant difference between them.
 
 ### Other
 

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -35,6 +35,9 @@ statistically significant difference between them.
 - [`alpha-g-wire-gain-calibration`](src/bin/alpha-g-wire-gain-calibration/README.md):
 Gain calibration of the anode wire signals.
 
+#### Pads
+- [`alpha-g-pad-noise-statistics`](src/bin/alpha-g-pad-noise-statistics/README.md):
+Statistical analysis of the pad signals during a noise run.
 
 ### Other
 

--- a/analysis/src/bin/alpha-g-pad-baseline-comparison/README.md
+++ b/analysis/src/bin/alpha-g-pad-baseline-comparison/README.md
@@ -1,0 +1,6 @@
+# `alpha-g-pad-baseline-comparison`
+
+Compare pad baseline calibration files to determine of there is a
+statistically significant difference between them. Run the
+`alpha-g-pad-baseline-comparison --help` command to make sure you have
+installed the `alpha-g-analysis` package and print help information.

--- a/analysis/src/bin/alpha-g-pad-baseline-comparison/main.rs
+++ b/analysis/src/bin/alpha-g-pad-baseline-comparison/main.rs
@@ -1,0 +1,153 @@
+//! Compare pad baseline calibration files to determine if there is a
+//! statistically significant difference between them.
+//!
+//! Generate an updated calibration file if there is a significant difference.
+
+use crate::statistics::tost;
+use alpha_g_detector::padwing::map::{
+    TpcPadColumn, TpcPadPosition, TpcPadRow, TPC_PAD_COLUMNS, TPC_PAD_ROWS,
+};
+use anyhow::{bail, ensure, Context, Result};
+use clap::Parser;
+use std::collections::HashMap;
+use std::fs::File;
+use std::path::PathBuf;
+
+mod statistics;
+
+#[derive(Parser)]
+#[command(author, version)]
+#[command(about = "Compare pad baseline calibration files", long_about = None)]
+struct Args {
+    /// Previous calibration file.
+    #[arg(long, value_parser(parse_calibration_file))]
+    // The tuple represents (baseline, error, number of samples).
+    previous: HashMap<TpcPadPosition, (f64, f64, usize)>,
+    /// New calibration file used to identify potential changes.
+    #[arg(long, value_parser(parse_calibration_file))]
+    discovery: HashMap<TpcPadPosition, (f64, f64, usize)>,
+    /// Path where output files will be saved to.
+    #[arg(short, long, default_value = "./", value_parser(parse_directory))]
+    output_path: PathBuf,
+}
+
+// This is the minimum difference in baseline that is considered significant.
+const TOST_LIMIT: f64 = 9.0;
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    ensure!(
+        args.previous != args.discovery,
+        "both calibration files are identical"
+    );
+
+    let changed_channels = find_different_channels(&args.previous, &args.discovery);
+    if changed_channels.is_empty() {
+        println!("No significant changes were found");
+    } else {
+        println!("Found {} significant change(s)", changed_channels.len());
+        // The values in `new_update` are `Option` to keep track of channels
+        // that stopped working (i.e. present in previous, but absent in
+        // discovery). These channels are overwritten with None.
+        let new_update: HashMap<_, _> = changed_channels
+            .iter()
+            .map(|&pad| (pad, args.discovery.get(&pad).copied()))
+            .collect();
+        let mut new_complete = args.previous.clone();
+        for (pad, value) in new_update.iter() {
+            match value {
+                Some(value) => new_complete.insert(*pad, *value),
+                None => new_complete.remove(pad),
+            };
+        }
+
+        let update_filename = args.output_path.join("pad_baseline_update.ron");
+        let update_file = File::create(&update_filename)
+            .with_context(|| format!("failed to create `{}`", update_filename.display()))?;
+        ron::ser::to_writer(update_file, &new_update).with_context(|| {
+            format!(
+                "failed to serialize update calibration to `{}`",
+                update_filename.display()
+            )
+        })?;
+        println!("Created `{}`", update_filename.display());
+
+        let complete_filename = args.output_path.join("pad_baseline_complete.ron");
+        let complete_file = File::create(&complete_filename)
+            .with_context(|| format!("failed to create `{}`", complete_filename.display()))?;
+        ron::ser::to_writer(complete_file, &new_complete).with_context(|| {
+            format!(
+                "failed to serialize complete calibration to `{}`",
+                complete_filename.display()
+            )
+        })?;
+        println!("Created `{}`", complete_filename.display());
+    }
+    Ok(())
+}
+
+/// Parse a baseline calibration file.
+/// The file is expected to be valid RON, and should deserialize to a HashMap
+/// of TpcPadPosition to (f64, f64, usize).
+fn parse_calibration_file(s: &str) -> Result<HashMap<TpcPadPosition, (f64, f64, usize)>> {
+    let contents = std::fs::read(s).with_context(|| format!("failed to read `{s}`"))?;
+    ron::de::from_bytes(&contents).with_context(|| format!("failed to deserialize `{s}`"))
+}
+
+/// Parse `--output-path` flag as valid directory
+fn parse_directory(s: &str) -> Result<PathBuf> {
+    let path: PathBuf = s.into();
+    if path.is_dir() {
+        Ok(path)
+    } else {
+        bail!(
+            "`{}` is not pointing to a directory on disk",
+            path.display()
+        )
+    }
+}
+
+/// Compare two baseline calibration files to determine if there is a
+/// statistically significant difference between them.
+/// Return a vector with the TpcPadPosition of the pads that have a
+/// statistically significant difference.
+fn find_different_channels(
+    previous: &HashMap<TpcPadPosition, (f64, f64, usize)>,
+    discovery: &HashMap<TpcPadPosition, (f64, f64, usize)>,
+) -> Vec<TpcPadPosition> {
+    let mut changed_pads = Vec::new();
+
+    for row in 0..TPC_PAD_ROWS {
+        let row = TpcPadRow::try_from(row).unwrap();
+        for column in 0..TPC_PAD_COLUMNS {
+            let column = TpcPadColumn::try_from(column).unwrap();
+            let pad = TpcPadPosition { row, column };
+
+            let previous_sample = previous.get(&pad);
+            let discovery_sample = discovery.get(&pad);
+
+            match (previous_sample, discovery_sample) {
+                // Channel is, and was, working
+                (Some(previous_sample), Some(discovery_sample)) => {
+                    let p_value = tost(*previous_sample, *discovery_sample, TOST_LIMIT);
+                    // p-value less than 0.05 indicates a statistically significant
+                    // effect to reject the null hypothesis.
+                    // In our case, the null hypothesis is that the difference
+                    // between the two sample means is greater than TOST_LIMIT.
+                    // i.e.
+                    // low p-value    ->    means are equivalent within TOST_LIMIT
+                    if p_value >= 0.05 {
+                        changed_pads.push(pad);
+                    }
+                }
+                // Channel is not working, but was not working before
+                // i.e. nothing changed
+                (None, None) => (),
+                // A new channel stopped/started working.
+                _ => changed_pads.push(pad),
+            }
+        }
+    }
+
+    changed_pads
+}

--- a/analysis/src/bin/alpha-g-pad-baseline-comparison/statistics.rs
+++ b/analysis/src/bin/alpha-g-pad-baseline-comparison/statistics.rs
@@ -1,0 +1,57 @@
+use statrs::distribution::{ContinuousCDF, StudentsT};
+
+/// Calculate the t-statistic given a pair of samples and an equivalence limit.
+fn t_statistic(
+    // The samples are: (mean, error, number of samples)
+    new_calib: (f64, f64, usize),
+    old_calib: (f64, f64, usize),
+    limit: f64,
+) -> f64 {
+    let (new_mean, new_std_err, _) = new_calib;
+    let (old_mean, old_std_err, _) = old_calib;
+    // Welch's unequal variance t-test
+    (new_mean - old_mean - limit) / (new_std_err.powi(2) + old_std_err.powi(2)).sqrt()
+}
+
+/// Calculate the degrees of freedom given a pair of samples.
+fn dof(new_calib: (f64, f64, usize), old_calib: (f64, f64, usize)) -> f64 {
+    let (_, new_std_err, new_sample_size) = new_calib;
+    let (_, old_std_err, old_sample_size) = old_calib;
+    // Sattherthwaite correction
+    (old_std_err.powi(2) + new_std_err.powi(2)).powi(2)
+        / (old_std_err.powi(4) / (old_sample_size - 1) as f64
+            + new_std_err.powi(4) / (new_sample_size - 1) as f64)
+}
+
+/// Calculate the p-value given t_lower, t_upper and degrees of freedom.
+fn p_value(t_lower: f64, t_upper: f64, dof: f64) -> f64 {
+    let student_t = StudentsT::new(0.0, 1.0, dof).unwrap();
+
+    let p_lower = 1.0 - student_t.cdf(t_lower);
+    let p_upper = student_t.cdf(t_upper);
+    // Two samples are considered equivalent if both p-values are below 0.05.
+    // Hence, the maximum of the two p-values is returned.
+    if p_lower > p_upper {
+        p_lower
+    } else {
+        p_upper
+    }
+}
+
+/// Perform a TOST test on a pair of samples and an equivalence limit.
+/// Returns the p-value of the test.
+// The null hypothesis is that the difference between the two means is outside
+// the equivalence limit.
+// i.e. low p-value -> they are equivalent
+pub(crate) fn tost(new_calib: (f64, f64, usize), old_calib: (f64, f64, usize), limit: f64) -> f64 {
+    let limit = limit.abs();
+
+    let t_lower = t_statistic(new_calib, old_calib, -limit);
+    let t_upper = t_statistic(new_calib, old_calib, limit);
+    let dof = dof(new_calib, old_calib);
+
+    p_value(t_lower, t_upper, dof)
+}
+
+#[cfg(test)]
+mod tests;

--- a/analysis/src/bin/alpha-g-pad-baseline-comparison/statistics/tests.rs
+++ b/analysis/src/bin/alpha-g-pad-baseline-comparison/statistics/tests.rs
@@ -1,0 +1,43 @@
+use super::*;
+
+#[test]
+fn test_t_statistic() {
+    let old_calib = (19.27, 1.3624843619, 11);
+    let new_calib = (23.69, 2.5302781848, 13);
+
+    let t = t_statistic(old_calib, new_calib, 0.0);
+    let diff = (t + 1.538).abs();
+    assert!(diff < 0.0001);
+}
+
+#[test]
+fn test_dof() {
+    let old_calib = (19.27, 1.3624843619, 11);
+    let new_calib = (23.69, 2.5302781848, 13);
+
+    let dof = dof(old_calib, new_calib);
+    let diff = (dof - 18.1378).abs();
+    assert!(diff < 0.0001);
+}
+
+#[test]
+fn test_p_value() {
+    let old_calib = (19.27, 1.3624843619, 11);
+    let new_calib = (23.69, 2.5302781848, 13);
+
+    let t = t_statistic(old_calib, new_calib, 0.0);
+
+    let p = p_value(t, t, 18.0);
+    let diff = (p - 0.9292836703899112).abs();
+    assert!(diff < 0.0001);
+}
+
+#[test]
+fn equivalence_test() {
+    let old_calib = (19.27, 1.3624843619, 11);
+    let new_calib = (23.69, 2.5302781848, 13);
+
+    let p = tost(old_calib, new_calib, 10.0);
+    let diff = (p - 0.033936176335811474).abs();
+    assert!(diff < 0.0001);
+}

--- a/analysis/src/bin/alpha-g-pad-noise-statistics/README.md
+++ b/analysis/src/bin/alpha-g-pad-noise-statistics/README.md
@@ -1,0 +1,16 @@
+# `alpha-g-pad-noise-statistics`
+
+Statistical analysis of the pad signals during a noise run. Generate
+(among other things) a calibration file with the baseline of all pad channels.
+Run the `alpha-g-pad-noise-statistics --help` command to make sure you have
+installed the `alpha-g-analysis` package and print help information.
+
+## Requirements
+
+All input MIDAS files should belong to the same run with the following settings:
+- Pulser enabled.
+- Field wire pulser disabled.
+- BSC pulser disabled.
+- Trigger pulser must be enabled.
+- There should be no other active trigger sources.
+- Pad data suppression must be disabled.

--- a/analysis/src/bin/alpha-g-pad-noise-statistics/main.rs
+++ b/analysis/src/bin/alpha-g-pad-noise-statistics/main.rs
@@ -1,0 +1,365 @@
+//! Statistical analysis of the pad signals during a noise run.
+
+use alpha_g_detector::midas::{
+    EventId, PadwingBankName, BSC_PULSER_ENABLE_JSON_PTR, FIELD_WIRE_PULSER_ENABLE_JSON_PTR,
+    PULSER_ENABLE_JSON_PTR, PWB_FORCE_CHANNELS_JSON_PTR, TRIGGER_PULSER_JSON_PTR,
+    TRIGGER_SOURCES_JSON_PTR,
+};
+use alpha_g_detector::padwing::map::{
+    TpcPadColumn, TpcPadPosition, TpcPadRow, TPC_PADS, TPC_PAD_COLUMNS, TPC_PAD_ROWS,
+};
+use alpha_g_detector::padwing::{ChannelId, Chunk, PwbPacket};
+use anyhow::{bail, ensure, Context, Result};
+use clap::Parser;
+use indicatif::{ProgressBar, ProgressStyle};
+use memmap2::Mmap;
+use midasio::read::file::{initial_timestamp_unchecked, run_number_unchecked, FileView};
+use serde_json::{json, Value};
+use statrs::statistics::Statistics;
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[command(author, version)]
+#[command(about = "Statistical analysis of the pad signals during a noise run", long_about = None)]
+struct Args {
+    /// MIDAS files from the noise run.
+    #[arg(required = true)]
+    files: Vec<PathBuf>,
+    /// Path where all output files will be saved into.
+    #[arg(short, long, default_value = "./", value_parser(parse_directory))]
+    output_path: PathBuf,
+    /// Print detailed information about errors (if any).
+    #[arg(short, long)]
+    verbose: bool,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let (run_number, mmaps) = try_valid_mmaps(args.files).context("invalid input file")?;
+
+    let (errors_count, noise_samples) =
+        try_noise_samples(mmaps, args.verbose).context("failed to sample noise")?;
+    if errors_count != 0 {
+        eprintln!("Warning: found `{errors_count}` error(s)/warning(s)");
+    }
+
+    let baseline_stats = get_baseline_statistics(&noise_samples);
+    // JSON makes it difficult to deal with non-string keys
+    // (e.g. TpcPadPosition). Not worth the effort; use RON instead.
+    let baseline_filename = args
+        .output_path
+        .join(format!("pad_baseline_statistics_{run_number}.ron"));
+    let baseline_file = File::create(&baseline_filename)
+        .with_context(|| format!("failed to create `{}`", baseline_filename.display()))?;
+    ron::ser::to_writer(baseline_file, &baseline_stats).with_context(|| {
+        format!(
+            "failed to serialize baseline statistics into `{}`",
+            baseline_filename.display()
+        )
+    })?;
+    println!("Created `{}`", baseline_filename.display());
+
+    Ok(())
+}
+
+/// Parse `--output-path` flag as valid directory
+fn parse_directory(s: &str) -> Result<PathBuf> {
+    let path: PathBuf = s.into();
+    if path.is_dir() {
+        Ok(path)
+    } else {
+        bail!(
+            "`{}` is not pointing to a directory on disk",
+            path.display()
+        )
+    }
+}
+
+/// Try to get a vector of valid memory maps from a collection of paths. Ensure
+/// that all the memory maps are valid:
+/// - All belong to the same run number.
+/// - There are no duplicates (by timestamp).
+// Do not validate the entire MIDAS format (here) because it is too expensive.
+// Instead, only validate the run number and the timestamp.
+//
+// Return the memory maps in a tuple with their corresponding file path to keep
+// context (helpful for error messages).
+fn try_valid_mmaps(
+    file_names: impl IntoIterator<Item = PathBuf>,
+) -> Result<(u32, Vec<(PathBuf, Mmap)>)> {
+    let mut run_number = None;
+    let mut timestamps = HashSet::new();
+
+    let mmaps = file_names
+        .into_iter()
+        .map(|path| {
+            let file = File::open(&path)
+                .with_context(|| format!("failed to open `{}`", path.display()))?;
+            let mmap = unsafe { Mmap::map(&file) }
+                .with_context(|| format!("failed to memory map `{}`", path.display()))?;
+
+            let current_run_number = run_number_unchecked(&mmap).with_context(|| {
+                format!("failed to read run number from `{}`", path.display())
+            })?;
+            if let Some(run_number) = run_number {
+                ensure!(
+                    run_number == current_run_number,
+                    "bad run number in `{}` (expected `{run_number}`, found `{current_run_number}`)",
+                    path.display()
+                );
+            } else {
+                run_number = Some(current_run_number);
+            }
+
+            let initial_timestamp = initial_timestamp_unchecked(&mmap).with_context(|| {
+                format!("failed to read initial timestamp from `{}`", path.display())
+            })?;
+            ensure!(
+                timestamps.insert(initial_timestamp),
+                "duplicate initial timestamp `{initial_timestamp}` in `{}`",
+                path.display()
+            );
+
+            Ok((path, mmap))
+        })
+        .collect::<Result<_>>()?;
+
+    Ok((run_number.unwrap(), mmaps))
+}
+
+/// Validate the settings for a given ODB.
+/// - Pulser must be enabled.
+/// - Field wire pulser must be disabled.
+/// - BSC pulser must be disabled.
+/// - Trigger pulser must be enabled.
+/// - There should be no other active trigger sources.
+/// - Pad data suppression must be disabled.
+fn validate_odb_settings(odb: &[u8]) -> Result<()> {
+    let odb: Value = serde_json::from_slice(odb).context("failed to parse ODB as JSON")?;
+
+    let pulser_enable = odb
+        .pointer(PULSER_ENABLE_JSON_PTR)
+        .with_context(|| format!("failed to read `{PULSER_ENABLE_JSON_PTR}` from ODB"))?;
+    ensure!(pulser_enable == &json!(true), "pulser not enabled");
+
+    let field_wire_pulser_enable = odb
+        .pointer(FIELD_WIRE_PULSER_ENABLE_JSON_PTR)
+        .with_context(|| {
+            format!("failed to read `{FIELD_WIRE_PULSER_ENABLE_JSON_PTR}` from ODB")
+        })?;
+    ensure!(
+        field_wire_pulser_enable == &json!(false),
+        "field wire pulser not disabled"
+    );
+
+    let bsc_pulser_enable = odb
+        .pointer(BSC_PULSER_ENABLE_JSON_PTR)
+        .with_context(|| format!("failed to read `{BSC_PULSER_ENABLE_JSON_PTR}` from ODB"))?;
+    ensure!(
+        bsc_pulser_enable == &json!(false),
+        "bsc pulser not disabled"
+    );
+
+    let trigger_pulser = odb
+        .pointer(TRIGGER_PULSER_JSON_PTR)
+        .with_context(|| format!("failed to read `{TRIGGER_PULSER_JSON_PTR}` from ODB"))?;
+    ensure!(trigger_pulser == &json!(true), "trigger pulser not enabled");
+
+    let Value::Object(trigger_sources) = odb
+        .pointer(TRIGGER_SOURCES_JSON_PTR)
+        .with_context(|| format!("failed to read `{TRIGGER_SOURCES_JSON_PTR}` from ODB"))?
+        else {
+        bail!("invalid `{TRIGGER_SOURCES_JSON_PTR}` in ODB");
+        };
+    let active_trigger_sources = trigger_sources
+        .values()
+        .filter_map(|value| value.as_bool())
+        .filter(|&value| value)
+        .count();
+    ensure!(
+        active_trigger_sources == 1,
+        "found `{active_trigger_sources}` active trigger sources (expected 1)"
+    );
+
+    let pwb_force_channels = odb
+        .pointer(PWB_FORCE_CHANNELS_JSON_PTR)
+        .with_context(|| format!("failed to read `{PWB_FORCE_CHANNELS_JSON_PTR}` from ODB"))?;
+    ensure!(
+        pwb_force_channels == &json!(true),
+        "pad data suppression not disabled"
+    );
+
+    Ok(())
+}
+
+/// Determine if a waveform is noise.
+fn is_noise(_waveform: &[i16]) -> bool {
+    true
+}
+
+/// Get noise samples of all pad channels given a collection of memory mapped
+/// MIDAS files.
+/// Count the number of non-critical errors/warnings found.
+///
+/// Return an error if a memory map is not a valid MIDAS file, or an invalid
+/// setting is found in the ODB.
+/// If verbose is true, print the errors/warnings to stderr.
+// Allow this complex return type because this is not a library.
+// It is just convenient.
+#[allow(clippy::type_complexity)]
+fn try_noise_samples(
+    mmaps: Vec<(PathBuf, Mmap)>,
+    verbose: bool,
+    // Noise samples are Option because it is important to keep samples aligned
+    // in time between different channels. Hence, add None to the vector when
+    // there is no sample for a given channel.
+    // This is particularly important to correctly calculate the covariance
+    // matrix.
+) -> Result<(usize, HashMap<TpcPadPosition, Vec<Option<i16>>>)> {
+    let mut errors_count = 0;
+    let mut noise_samples: HashMap<_, Vec<_>> = HashMap::new();
+
+    let bar = ProgressBar::new(mmaps.len().try_into().unwrap()).with_style(
+        ProgressStyle::with_template("  Sampling [{bar:25}] {percent}%,  ETA: {eta}")
+            .unwrap()
+            .progress_chars("=> "),
+    );
+    bar.tick();
+    for (path, mmap) in mmaps {
+        let file_view = FileView::try_from(&mmap[..])
+            .with_context(|| format!("`{}` is not a valid MIDAS file", path.display()))?;
+        let run_number = file_view.run_number();
+        validate_odb_settings(file_view.initial_odb())
+            .with_context(|| format!("invalid ODB settings in `{}`", path.display()))?;
+
+        for event_view in file_view
+            .into_iter()
+            .filter(|event| matches!(EventId::try_from(event.id()), Ok(EventId::Main)))
+        {
+            // This temporary HashMap helps to keep track of missing channels in
+            // the current event. This is important to maintain time alignment
+            // between channels.
+            let mut temp = HashMap::new();
+
+            // Need to group chunks by board and chip.
+            let mut pwb_chunks_map: HashMap<_, Vec<_>> = HashMap::new();
+
+            for bank_view in event_view
+                .into_iter()
+                .filter(|b| PadwingBankName::try_from(b.name()).is_ok())
+            {
+                let chunk = match Chunk::try_from(bank_view.data_slice()) {
+                    Ok(chunk) => chunk,
+                    Err(error) => {
+                        errors_count += 1;
+                        if verbose {
+                            bar.println(format!(
+                                "Error: event `{}`, bank `{}`, {error}",
+                                event_view.serial_number(),
+                                bank_view.name(),
+                            ));
+                        }
+                        continue;
+                    }
+                };
+                let key = (chunk.board_id(), chunk.after_id());
+                pwb_chunks_map.entry(key).or_default().push(chunk);
+            }
+
+            for chunks in pwb_chunks_map.into_values() {
+                let packet = match PwbPacket::try_from(chunks) {
+                    Ok(packet) => packet,
+                    Err(error) => {
+                        errors_count += 1;
+                        if verbose {
+                            bar.println(format!(
+                                "Error: event `{}`, {error}",
+                                event_view.serial_number(),
+                            ));
+                        }
+                        continue;
+                    }
+                };
+                let board_id = packet.board_id();
+                let after_id = packet.after_id();
+                for &channel_id in packet.channels_sent() {
+                    if let ChannelId::Pad(pad_channel_id) = channel_id {
+                        let pad_position =
+                            TpcPadPosition::try_new(run_number, board_id, after_id, pad_channel_id)
+                                .context("pad position mapping failed")?;
+                        // A waveform is guaranteed to exist and not be empty if
+                        // the channel was sent. It is safe to unwrap.
+                        let waveform = packet.waveform_at(channel_id).unwrap();
+                        if !is_noise(waveform) {
+                            continue;
+                        }
+                        // No particular reason to take the sample from the
+                        // middle of the waveform. I just want to avoid the
+                        // first and last last few samples (SCA analog mux
+                        // switching noise. See elog 3310).
+                        let middle_index = (waveform.len() - 1) / 2;
+                        temp.insert(pad_position, waveform[middle_index]);
+                    }
+                }
+            }
+            // Add all the noise samples found in the current event to the
+            // final hash map.
+            // If a channel is missing in the current event, add None to the
+            // vector to keep the time alignment.
+            for row in 0..TPC_PAD_ROWS {
+                let row = TpcPadRow::try_from(row).unwrap();
+                for column in 0..TPC_PAD_COLUMNS {
+                    let column = TpcPadColumn::try_from(column).unwrap();
+                    let pad_position = TpcPadPosition { column, row };
+                    let sample = temp.get(&pad_position).copied();
+                    noise_samples.entry(pad_position).or_default().push(sample);
+                }
+            }
+        }
+        bar.inc(1);
+    }
+    bar.finish_and_clear();
+    // If all samples are None, it means that the channel is missing.
+    // Just remove it from the hash map.
+    noise_samples.retain(|_, samples| samples.iter().any(Option::is_some));
+
+    let missing_channels = TPC_PADS - noise_samples.len();
+    errors_count += missing_channels;
+    if verbose && missing_channels > 0 {
+        for row in 0..TPC_PAD_ROWS {
+            let row = TpcPadRow::try_from(row).unwrap();
+            for column in 0..TPC_PAD_COLUMNS {
+                let column = TpcPadColumn::try_from(column).unwrap();
+                let pad_position = TpcPadPosition { column, row };
+                if !noise_samples.contains_key(&pad_position) {
+                    eprintln!("Warning: no noise samples for `{pad_position:?}`");
+                }
+            }
+        }
+    }
+
+    Ok((errors_count, noise_samples))
+}
+
+/// Get the pad baseline statistics from the noise samples.
+fn get_baseline_statistics(
+    noise_samples: &HashMap<TpcPadPosition, Vec<Option<i16>>>,
+    // The tuple is (mean, error, number of samples).
+) -> HashMap<TpcPadPosition, (f64, f64, usize)> {
+    noise_samples
+        .iter()
+        .map(|(&pad_position, samples)| {
+            let noise: Vec<f64> = samples
+                .iter()
+                .filter_map(|&sample| sample.map(f64::from))
+                .collect();
+            let mean = noise.clone().mean();
+            let std_dev = noise.clone().std_dev();
+            let mean_error = std_dev / (noise.len() as f64).sqrt();
+
+            (pad_position, (mean, mean_error, noise.len()))
+        })
+        .collect()
+}

--- a/detector/src/midas.rs
+++ b/detector/src/midas.rs
@@ -20,6 +20,9 @@ pub const BSC_PULSER_ENABLE_JSON_PTR: &str = "/Equipment/CTRL/Settings/BscPulser
 pub const FIELD_WIRE_PULSER_ENABLE_JSON_PTR: &str = "/Equipment/CTRL/Settings/FwPulserEnable";
 /// JSON pointer that identifies the pulser enable flag in the ODB.
 pub const PULSER_ENABLE_JSON_PTR: &str = "/Equipment/CTRL/Settings/Pulser/Enable";
+/// JSON pointer that identifies the PWB force channels flag in the ODB (i.e.
+/// disable data suppression).
+pub const PWB_FORCE_CHANNELS_JSON_PTR: &str = "/Equipment/CTRL/Settings/PWB/ch_force";
 /// JSON pointer that identifies the PWB data suppression threshold in the ODB.
 // This is the same for all Reset, FPN, and Pad channels.
 pub const PWB_SUPPRESSION_THRESHOLD_JSON_PTR: &str = "/Equipment/CTRL/Settings/PWB/ch_threshold";

--- a/detector/src/midas/tests.rs
+++ b/detector/src/midas/tests.rs
@@ -57,6 +57,14 @@ fn trigger_pulser_json_ptr() {
 }
 
 #[test]
+fn pwb_force_channels_json_ptr() {
+    assert_eq!(
+        PWB_FORCE_CHANNELS_JSON_PTR,
+        "/Equipment/CTRL/Settings/PWB/ch_force"
+    );
+}
+
+#[test]
 fn pwb_suppression_threshold_json_ptr() {
     assert_eq!(
         PWB_SUPPRESSION_THRESHOLD_JSON_PTR,

--- a/detector/src/padwing/map.rs
+++ b/detector/src/padwing/map.rs
@@ -463,8 +463,8 @@ pub enum MapTpcPadPositionError {
 /// Position of a pad in the rTPC.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct TpcPadPosition {
-    column: TpcPadColumn,
-    row: TpcPadRow,
+    pub column: TpcPadColumn,
+    pub row: TpcPadRow,
 }
 impl TpcPadPosition {
     /// Map a [`TpcPwbPosition`] and [`PwbPadPosition`] to a [`TpcPadPosition`].
@@ -526,58 +526,6 @@ impl TpcPadPosition {
         let board_position = TpcPwbPosition::try_new(run_number, board_id)?;
         let pad_position = PwbPadPosition::try_new(run_number, after_id, pad_channel_id)?;
         Ok(TpcPadPosition::new(board_position, pad_position))
-    }
-    /// Return the column of the pad within the rTPC.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use alpha_g_detector::padwing::map::{TpcPadPosition, TpcPadColumn, TpcPwbPosition, PwbPadPosition};
-    /// use alpha_g_detector::padwing::{AfterId, PadChannelId, BoardId};
-    ///
-    /// let run_number = 5000;
-    /// let board = BoardId::try_from("26")?;
-    /// let board_pos = TpcPwbPosition::try_new(run_number, board)?;
-    ///
-    /// let after = AfterId::try_from('A')?;
-    /// let pad_channel = PadChannelId::try_from(1)?;
-    /// let pad_pos = PwbPadPosition::try_new(run_number, after, pad_channel)?;
-    ///
-    /// let tpc_pad_position = TpcPadPosition::new(board_pos, pad_pos);
-    ///
-    /// assert_eq!(tpc_pad_position.column(), TpcPadColumn::try_from(5)?);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn column(&self) -> TpcPadColumn {
-        self.column
-    }
-    /// Return the row of the pad within the rTPC.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use alpha_g_detector::padwing::map::{TpcPadPosition, TpcPadRow, TpcPwbPosition, PwbPadPosition};
-    /// use alpha_g_detector::padwing::{AfterId, PadChannelId, BoardId};
-    ///
-    /// let run_number = 5000;
-    /// let board = BoardId::try_from("26")?;
-    /// let board_pos = TpcPwbPosition::try_new(run_number, board)?;
-    ///
-    /// let after = AfterId::try_from('A')?;
-    /// let pad_channel = PadChannelId::try_from(1)?;
-    /// let pad_pos = PwbPadPosition::try_new(run_number, after, pad_channel)?;
-    ///
-    /// let tpc_pad_position = TpcPadPosition::new(board_pos, pad_pos);
-    ///
-    /// assert_eq!(tpc_pad_position.row(), TpcPadRow::try_from(432)?);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn row(&self) -> TpcPadRow {
-        self.row
     }
     /// Return the `z` coordinate (in meters) of the pad center within the rTPC.
     /// The `z` coordinate is measured from the center of the rTPC (positive

--- a/detector/src/padwing/map/tests.rs
+++ b/detector/src/padwing/map/tests.rs
@@ -561,7 +561,7 @@ fn tpc_pad_position_column() {
             column: TpcPadColumn(i),
             row: TpcPadRow(0),
         };
-        assert_eq!(position.column(), TpcPadColumn(i));
+        assert_eq!(position.column, TpcPadColumn(i));
     }
 }
 
@@ -572,7 +572,7 @@ fn tpc_pad_position_row() {
             column: TpcPadColumn(0),
             row: TpcPadRow(i),
         };
-        assert_eq!(position.row(), TpcPadRow(i));
+        assert_eq!(position.row, TpcPadRow(i));
     }
 }
 

--- a/detector/src/padwing/map/tests.rs
+++ b/detector/src/padwing/map/tests.rs
@@ -599,7 +599,8 @@ fn tpc_pad_position_ron_roundtrip() {
                 row: TpcPadRow(row),
             };
             let pad_position_ron = ron::to_string(&pad_position).unwrap();
-            let pad_position_deserialized: TpcPadPosition = ron::from_str(&pad_position_ron).unwrap();
+            let pad_position_deserialized: TpcPadPosition =
+                ron::from_str(&pad_position_ron).unwrap();
             assert_eq!(pad_position, pad_position_deserialized);
         }
     }

--- a/detector/src/padwing/map/tests.rs
+++ b/detector/src/padwing/map/tests.rs
@@ -516,12 +516,48 @@ fn try_from_index_tpc_pad_column() {
 }
 
 #[test]
+fn from_tpc_pad_column_usize() {
+    for i in 0..=31 {
+        let pad_column = TpcPadColumn::try_from(i).unwrap();
+        assert_eq!(usize::from(pad_column), i);
+    }
+}
+
+#[test]
+fn tpc_pad_column_ron_roundtrip() {
+    for i in 0..=31 {
+        let pad_column = TpcPadColumn::try_from(i).unwrap();
+        let pad_column_ron = ron::to_string(&pad_column).unwrap();
+        let pad_column_deserialized: TpcPadColumn = ron::from_str(&pad_column_ron).unwrap();
+        assert_eq!(pad_column, pad_column_deserialized);
+    }
+}
+
+#[test]
 fn try_from_index_tpc_pad_row() {
     for i in 0..=575 {
         assert_eq!(TpcPadRow::try_from(i).unwrap(), TpcPadRow(i));
     }
     for i in 576..=19000 {
         assert!(TpcPadRow::try_from(i).is_err());
+    }
+}
+
+#[test]
+fn from_tpc_pad_row_usize() {
+    for i in 0..=575 {
+        let pad_row = TpcPadRow::try_from(i).unwrap();
+        assert_eq!(usize::from(pad_row), i);
+    }
+}
+
+#[test]
+fn tpc_pad_row_ron_roundtrip() {
+    for i in 0..=575 {
+        let pad_row = TpcPadRow::try_from(i).unwrap();
+        let pad_row_ron = ron::to_string(&pad_row).unwrap();
+        let pad_row_deserialized: TpcPadRow = ron::from_str(&pad_row_ron).unwrap();
+        assert_eq!(pad_row, pad_row_deserialized);
     }
 }
 
@@ -550,6 +586,21 @@ fn tpc_pad_position_new() {
                     row: TpcPadRow(row),
                 }
             );
+        }
+    }
+}
+
+#[test]
+fn tpc_pad_position_ron_roundtrip() {
+    for row in 0..=575 {
+        for column in 0..=31 {
+            let pad_position = TpcPadPosition {
+                column: TpcPadColumn(column),
+                row: TpcPadRow(row),
+            };
+            let pad_position_ron = ron::to_string(&pad_position).unwrap();
+            let pad_position_deserialized: TpcPadPosition = ron::from_str(&pad_position_ron).unwrap();
+            assert_eq!(pad_position, pad_position_deserialized);
         }
     }
 }


### PR DESCRIPTION
Implement the binaries required for the pad baseline calibration:

1. `alpha-g-pad-noise-statistics`.
2. `alpha-g-pad-baseline-comparison`.