### PR TITLE
Make vertex reconstruction deterministic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,11 +64,13 @@ dependencies = [
  "dyn-stack",
  "faer-cholesky",
  "faer-core",
+ "itertools",
  "lazy_static",
  "num-complex",
  "ron",
  "serde",
  "serde_json",
+ "statrs",
  "thiserror",
  "uom",
 ]
@@ -756,6 +758,15 @@ dependencies = [
  "io-lifetimes",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
 ]
 
 [[package]]

--- a/physics/Cargo.toml
+++ b/physics/Cargo.toml
@@ -17,11 +17,13 @@ argmin-math = "0.3.0"
 dyn-stack = "0.9.0"
 faer-cholesky = "0.9.1"
 faer-core = "0.9.1"
+itertools = "0.11.0"
 lazy_static = "1.4.0"
 num-complex = "0.4.4"
 ron = "0.8.0"
 serde = { version = "1.0.189", features = ["derive"] }
 serde_json = "1.0.95"
+statrs = "0.16.0"
 thiserror = "1.0.40"
 uom = { version = "0.35.0", features = ["use_serde"] }
 

--- a/physics/src/deconvolution.rs
+++ b/physics/src/deconvolution.rs
@@ -35,7 +35,7 @@ fn nn_greedy_deconvolution(
     // Unnatural way of sliding the window, but it allows a 2x speedup by
     // jumping over chunks of the signal at a time.
     let mut i = 0;
-    while i < residual.len() - offset - look_ahead {
+    while i + offset + look_ahead <= residual.len() {
         let residual_window = &residual[i + offset..][..look_ahead];
         // Find the index of the last non-negative value in the residual window.
         // If there is any non-negative value, it means that there was no input,

--- a/physics/src/lib.rs
+++ b/physics/src/lib.rs
@@ -360,6 +360,16 @@ impl MainEvent {
         // The typical `tmin` is 100ish or greater. This just leaves about 20
         // or more time bins.
         remove_noise_after_t(&mut wire_inputs, 4 * t_min / 5);
+        // We need to iterate over the pad columns in a deterministic order.
+        // This is needed for complete deterministic vertex reconstruction
+        // because of the `track_fitting`. Floating point arithmetic is not
+        // associative, hence having SpacePoints in different orders will lead
+        // to some very small differences in the final vertices.
+        let pad_columns = {
+            let mut temp = pad_columns.into_iter().collect::<Vec<_>>();
+            temp.sort_unstable();
+            temp
+        };
 
         let mut avalanches = Vec::new();
         for column in pad_columns {

--- a/physics/src/reconstruction/track_finding.rs
+++ b/physics/src/reconstruction/track_finding.rs
@@ -1,7 +1,11 @@
 use crate::reconstruction::{Cluster, ClusteringResult};
 use crate::SpacePoint;
+use itertools::Itertools;
+use statrs::statistics::Statistics;
+use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use uom::si::f64::{Angle, Length, ReciprocalLength};
+use uom::si::length::meter;
 use uom::si::ratio::ratio;
 use uom::typenum::P2;
 
@@ -176,22 +180,52 @@ impl HoughSpaceAccumulator {
     // Remove a SpacePoint from the accumulator.
     fn remove(&mut self, point: SpacePoint) {
         for bin in self.get_bins(point) {
-            let Some(v) = self.accumulator.get_mut(&bin) else {
-                continue;
-            };
-            if let Some(pos) = v.iter().position(|p| *p == point) {
-                v.swap_remove(pos);
-            }
+            // We know that the point is in the accumulator, so it is safe to
+            // unwrap.
+            let vec = self.accumulator.get_mut(&bin).unwrap();
+            let pos = vec.iter().position(|p| *p == point).unwrap();
+            vec.swap_remove(pos);
         }
     }
     // Return the SpacePoints that voted for the most popular bin. Return an
     // empty vector if the accumulator is empty.
     fn most_popular(&self) -> Vec<SpacePoint> {
+        // The order in which values of a HashMap are iterated over is random.
+        // We need this function to be deterministic, hence we need some tie
+        // breaking for the case where multiple bins have the same maximum
+        // number of votes.
         self.accumulator
             .values()
-            .max_by_key(|v| v.len())
+            .max_set_by_key(|v| v.len())
+            .into_iter()
+            .max_by(|c1, c2| cluster_tie_breaker(c1, c2))
             .cloned()
             .unwrap_or_default()
+    }
+}
+
+// Assign a deterministic ordering/priority of two clusters when they have
+// the same number of points.
+// The better cluster is `Ordering::Greater`.
+fn cluster_tie_breaker(c1: &[SpacePoint], c2: &[SpacePoint]) -> Ordering {
+    let v1 = c1.iter().map(|p| p.r.get::<meter>()).variance();
+    let v2 = c2.iter().map(|p| p.r.get::<meter>()).variance();
+
+    match v1.partial_cmp(&v2) {
+        Some(Ordering::Less) => Ordering::Less,
+        Some(Ordering::Greater) => Ordering::Greater,
+        Some(Ordering::Equal) => {
+            let v1 = c1.iter().map(|p| p.z.get::<meter>()).variance();
+            let v2 = c2.iter().map(|p| p.z.get::<meter>()).variance();
+            // Can't be NaN since they didn't have NaN variance in r.
+            // Therefore, we can unwrap.
+            v2.partial_cmp(&v1).unwrap()
+        }
+        // If the clusters are empty (or are a single point), then we don't
+        // really care about the ordering. It can be random because these points
+        // will never make it pass the `min_num_points_per_cluster` filter (we
+        // need at least 3 for track fitting, etc).
+        None => Ordering::Equal,
     }
 }
 
@@ -235,6 +269,10 @@ fn largest_cluster(mut points: Vec<SpacePoint>, max_distance: Length) -> Vec<Spa
         clusters.push(cluster);
     }
 
-    clusters.sort_by_key(|c| c.len());
-    clusters.pop().unwrap_or_default()
+    clusters
+        .into_iter()
+        .max_set_by_key(|c| c.len())
+        .into_iter()
+        .max_by(|c1, c2| cluster_tie_breaker(c1, c2))
+        .unwrap_or_default()
 }

--- a/physics/src/reconstruction/track_finding.rs
+++ b/physics/src/reconstruction/track_finding.rs
@@ -16,7 +16,6 @@ use uom::typenum::P2;
 //
 // We can filter potential annihilation tracks (which originate close to the
 // origin) by finding straight lines in the u-v plane.
-
 pub(crate) fn cluster_spacepoints(
     mut sp: Vec<SpacePoint>,
     max_num_clusters: usize,
@@ -119,8 +118,8 @@ struct HoughSpaceAccumulator {
 
 // Conformal transformation from x-y plane to u-v plane.
 fn u_v(point: SpacePoint) -> (ReciprocalLength, ReciprocalLength) {
-    let u = (point.r * point.phi.cos()) / point.r.powi(P2::new());
-    let v = (point.r * point.phi.sin()) / point.r.powi(P2::new());
+    let u = point.x() / point.r.powi(P2::new());
+    let v = point.y() / point.r.powi(P2::new());
 
     (u, v)
 }
@@ -198,13 +197,10 @@ impl HoughSpaceAccumulator {
 
 // Calculate the Euclidean distance between two SpacePoints
 fn distance(a: SpacePoint, b: SpacePoint) -> Length {
-    let x_a = a.r * a.phi.cos();
-    let y_a = a.r * a.phi.sin();
-
-    let x_b = b.r * b.phi.cos();
-    let y_b = b.r * b.phi.sin();
-
-    ((x_a - x_b).powi(P2::new()) + (y_a - y_b).powi(P2::new()) + (a.z - b.z).powi(P2::new())).sqrt()
+    ((a.x() - b.x()).powi(P2::new())
+        + (a.y() - b.y()).powi(P2::new())
+        + (a.z - b.z).powi(P2::new()))
+    .sqrt()
 }
 
 // Given a collection of SpacePoints, find the largest subset of SpacePoints

--- a/physics/src/reconstruction/track_fitting.rs
+++ b/physics/src/reconstruction/track_fitting.rs
@@ -4,6 +4,7 @@ use crate::reconstruction::{
 use crate::SpacePoint;
 use argmin::core::{CostFunction, Error, Executor};
 use argmin::solver::neldermead::NelderMead;
+use itertools::Itertools;
 use num_complex::Complex;
 use std::f64::consts::PI;
 use uom::si::angle::radian;
@@ -124,16 +125,7 @@ fn three_template_points(
     // Return the:
     // (Smallest r, Middle r, Largest r)
 ) -> Result<(SpacePoint, SpacePoint, SpacePoint), TryTrackFromClusterError> {
-    let first = points
-        .iter()
-        .min_by(|a, b| a.r.partial_cmp(&b.r).unwrap())
-        .copied()
-        .unwrap();
-    let last = points
-        .iter()
-        .max_by(|a, b| a.r.partial_cmp(&b.r).unwrap())
-        .copied()
-        .unwrap();
+    let (&first, &last) = points.iter().minmax_by_key(|p| p.r).into_option().unwrap();
 
     let middle_r = (first.r + last.r) / 2.0;
     let middle = points


### PR DESCRIPTION
Two features make the vertex reconstruction non-deterministic:
1. Iterating over a hashmap.
2. Non-associativity of floating point arithmetic.

Both of these "issues" have been fixed to make vertex reconstruction 100% deterministic.