### PR TITLE
Remove `--skip` flag from core analysis binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
 
 [[package]]
 name = "alpha-g-analysis"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "alpha_g_detector",
  "alpha_g_physics",

--- a/analysis/Cargo.toml
+++ b/analysis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpha-g-analysis"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 description = "Analysis binaries for the ALPHA-g experiment"

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -16,7 +16,7 @@ The easiest way to get access to all `alpha-g-analysis` binaries is with
 Once `cargo` is installed, run the following command:
 
 ```bash
-cargo install alpha-g-analysis
+cargo install --locked alpha-g-analysis
 ```
 
 Finally, to check that the installation was successful, run:

--- a/analysis/src/bin/alpha-g-trg-scalers/main.rs
+++ b/analysis/src/bin/alpha-g-trg-scalers/main.rs
@@ -18,12 +18,6 @@ struct Args {
     /// Write the TRG scalers to `OUTPUT.csv`
     #[arg(short, long)]
     output: PathBuf,
-    /// Ignore the first `SKIP` number of events
-    /// The first event not skipped sets `t=0`
-    // The default here is used to skip the initial 10 synchronization software
-    // triggers.
-    #[arg(long, default_value = "10", verbatim_doc_comment)]
-    skip: usize,
     /// Print detailed information about errors (if any)
     #[arg(short, long)]
     verbose: bool,
@@ -103,7 +97,7 @@ fn main() -> Result<()> {
     }
     bar.finish_and_clear();
 
-    let rows = rows.into_iter().skip(args.skip).scan(
+    let rows = rows.into_iter().scan(
         (None, 0),
         |(previous, cumulative), (serial_number, trg_packet)| {
             let timestamp = trg_packet.map(|p| p.timestamp());

--- a/analysis/src/bin/alpha-g-vertices/main.rs
+++ b/analysis/src/bin/alpha-g-vertices/main.rs
@@ -21,12 +21,6 @@ struct Args {
     /// Write the reconstructed vertices to `OUTPUT.csv`
     #[arg(short, long)]
     output: PathBuf,
-    /// Ignore the first `SKIP` number of events
-    /// The first event not skipped sets `t=0`
-    // The default here is used to skip the initial 10 synchronization software
-    // triggers.
-    #[arg(long, default_value = "10", verbatim_doc_comment)]
-    skip: usize,
     /// Print detailed information about errors (if any)
     #[arg(short, long)]
     verbose: bool,
@@ -122,7 +116,7 @@ fn main() -> Result<()> {
     }
     tp_bar.finish_and_clear();
 
-    let rows = rows.into_iter().skip(args.skip).scan(
+    let rows = rows.into_iter().scan(
         (None, 0),
         |(previous, cumulative), (serial_number, timestamp, vertex)| {
             // If we don't have a timestamp, it is OK to use the previous one


### PR DESCRIPTION
This makes the output compatible with the `alphasoft` reconstruction.